### PR TITLE
Feature: Add TaxId to Stripe customers

### DIFF
--- a/app/lib/payment/gateways/stripe/base.rb
+++ b/app/lib/payment/gateways/stripe/base.rb
@@ -6,6 +6,10 @@ module Payment
           card: 'card'
         }.freeze
 
+        ALLOWED_TAXID_REGIONS = {
+          brazil: 'br_cpf'
+        }.freeze
+
         def initialize
           ::Stripe.api_key = RibonCoreApi.config[:stripe][:secret_key]
         end

--- a/app/lib/payment/gateways/stripe/entities/tax_id.rb
+++ b/app/lib/payment/gateways/stripe/entities/tax_id.rb
@@ -1,0 +1,19 @@
+module Payment
+  module Gateways
+    module Stripe
+      module Entities
+        class TaxId
+          def self.add_to_customer(stripe_customer:, national_id:)
+            ::Stripe::Customer.create_tax_id(
+              stripe_customer&.id,
+              {
+                type: Base::ALLOWED_TAXID_REGIONS[:brazil],
+                value: national_id
+              }
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/payment/gateways/stripe/entities/tax_id_spec.rb
+++ b/spec/lib/payment/gateways/stripe/entities/tax_id_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe Payment::Gateways::Stripe::Entities::TaxId do
+  describe '#add_to_customer' do
+    subject(:taxid_addition_call) do
+      described_class.add_to_customer(stripe_customer: stripe_customer, national_id: national_id)
+    end
+
+    let(:gateway) { Payment::Gateways::Stripe::Base }
+
+    let(:stripe_customer) { OpenStruct.new({ id: 'cus_123' }) }
+    let(:national_id) { '11122233345' }
+
+    let(:method_parameters) do
+      [
+        stripe_customer.id,
+        {
+          type: gateway::ALLOWED_TAXID_REGIONS[:brazil],
+          value: national_id
+        }
+      ]
+    end
+
+    before do
+      allow(::Stripe::Customer).to receive(:create_tax_id)
+    end
+
+    it 'calls the Stripe::PaymentMethod with correct params' do
+      taxid_addition_call
+
+      expect(::Stripe::Customer)
+        .to have_received(:create_tax_id)
+        .with(*method_parameters)
+    end
+  end
+end


### PR DESCRIPTION
<!-- Delete any of those topics if they don't fit -->

# Description
- We need to append the TaxID to our customers. The TaxID is a national identifier that changes according to the country

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] It is urgent
- [ ] <span style="color:#d44037">Dangerous change</span>
