### PR TITLE
build: add wait-on-check action to worker deploys

### DIFF
--- a/.github/workflows/dev-worker-deploy.yml
+++ b/.github/workflows/dev-worker-deploy.yml
@@ -10,6 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+      - name: Wait for tests to succeed
+        uses: lewagon/wait-on-check-action@v1.1.2
+        with:
+          ref: ${{ github.ref }}
+          check-name: 'Tests (6)'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 15
       - name: Copy dockerfile
         run: cp .worker_config/Dockerfile Dockerfile
       - name: Generate deployment package

--- a/.github/workflows/staging-worker-deploy.yml
+++ b/.github/workflows/staging-worker-deploy.yml
@@ -10,6 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+      - name: Wait for tests to succeed
+        uses: lewagon/wait-on-check-action@v1.1.2
+        with:
+          ref: ${{ github.ref }}
+          check-name: 'Tests (6)'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 15
       - name: Copy dockerfile
         run: cp .worker_config/Dockerfile Dockerfile
       - name: Generate deployment package


### PR DESCRIPTION
<!-- Delete any of those topics if they don't fit -->

# Description
- Add step to wait for tests to succeed before deploying workers

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] It is urgent
- [ ] <span style="color:#d44037">Dangerous change</span>
