### PR TITLE
Feature/dapp 430

### DIFF
--- a/app/blueprints/integration_blueprint.rb
+++ b/app/blueprints/integration_blueprint.rb
@@ -1,7 +1,7 @@
 class IntegrationBlueprint < Blueprinter::Base
   identifier :id
 
-  fields :updated_at, :created_at, :name, :unique_address, :status, :integration_address
+  fields :updated_at, :created_at, :name, :unique_address, :status, :integration_address, :ticket_availability
 
   association :integration_wallet, blueprint: IntegrationWalletBlueprint
 end

--- a/app/commands/integrations/create_integration.rb
+++ b/app/commands/integrations/create_integration.rb
@@ -5,16 +5,15 @@ module Integrations
     prepend SimpleCommand
     include Web3
 
-    attr_reader :name, :status
+    attr_reader :integration_params
 
-    def initialize(name:, status:)
-      @name   = name
-      @status = status
+    def initialize(integration_params)
+      @integration_params = integration_params
     end
 
     def call
       with_exception_handle do
-        integration = Integration.create!(name:, status:, unique_address:)
+        integration = Integration.create!(enriched_integration_params)
         integration.create_integration_wallet!(encrypted_wallet)
 
         integration
@@ -22,6 +21,10 @@ module Integrations
     end
 
     private
+
+    def enriched_integration_params
+      integration_params.merge(unique_address:)
+    end
 
     def unique_address
       SecureRandom.uuid

--- a/app/controllers/api/v1/integrations_controller.rb
+++ b/app/controllers/api/v1/integrations_controller.rb
@@ -8,7 +8,7 @@ module Api
       end
 
       def create
-        command = Integrations::CreateIntegration.call(name: params[:name], status: params[:status])
+        command = Integrations::CreateIntegration.call(integration_params)
 
         if command.success?
           render json: IntegrationBlueprint.render(command.result), status: :created
@@ -33,7 +33,7 @@ module Api
       private
 
       def integration_params
-        params.permit(:name, :status, :id)
+        params.permit(:name, :status, :id, :ticket_availability_in_minutes)
       end
     end
   end

--- a/app/models/integrations/integration.rb
+++ b/app/models/integrations/integration.rb
@@ -10,6 +10,18 @@ class Integration < ApplicationRecord
     "#{base_url}#{unique_address}"
   end
 
+  def ticket_availability
+    if ticket_availability_in_minutes.present?
+      "#{ticket_availability_in_minutes} minutes"
+    else
+      'Everyday at midnight'
+    end
+  end
+
+  def daily_availability?
+    ticket_availability_in_minutes.nil?
+  end
+
   private
 
   def base_url

--- a/db/migrate/20220809182850_add_ticket_availability_in_minutes_to_integrations.rb
+++ b/db/migrate/20220809182850_add_ticket_availability_in_minutes_to_integrations.rb
@@ -1,0 +1,5 @@
+class AddTicketAvailabilityInMinutesToIntegrations < ActiveRecord::Migration[7.0]
+  def change
+    add_column :integrations, :ticket_availability_in_minutes, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_09_133508) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_09_182850) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -136,6 +136,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_09_133508) do
     t.datetime "updated_at", null: false
     t.string "status", default: "active"
     t.uuid "unique_address", default: -> { "gen_random_uuid()" }, null: false
+    t.integer "ticket_availability_in_minutes"
   end
 
   create_table "mobility_string_translations", force: :cascade do |t|

--- a/spec/commands/integrations/create_integration_spec.rb
+++ b/spec/commands/integrations/create_integration_spec.rb
@@ -4,11 +4,15 @@ require 'rails_helper'
 
 describe Integrations::CreateIntegration do
   describe '.call' do
-    subject(:command) { described_class.call(name:, status:) }
+    subject(:command) { described_class.call(params) }
 
     context 'when all the data is valid' do
-      let(:name) { 'Ribon' }
-      let(:status) { :active }
+      let(:params) do
+        {
+          name: 'Integration 1',
+          status: 'active'
+        }
+      end
 
       it 'creates a new integration' do
         expect { command }.to change(Integration, :count).by(1)
@@ -20,8 +24,12 @@ describe Integrations::CreateIntegration do
     end
 
     context 'when a data is invalid' do
-      let(:name) { 'Ribon' }
-      let(:status) { 'undefined' }
+      let(:params) do
+        {
+          name: 'Integration 1',
+          status: 'undefined'
+        }
+      end
 
       it 'raises an error' do
         expect(command.errors).to eq(

--- a/spec/factories/integrations.rb
+++ b/spec/factories/integrations.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     name { 'Renner' }
     status { :active }
     unique_address { 'f7be8d80-2406-4cb0-82eb-849346d327c9' }
+    ticket_availability_in_minutes { nil }
     integration_wallet { build(:integration_wallet) }
   end
 end

--- a/spec/models/integration_spec.rb
+++ b/spec/models/integration_spec.rb
@@ -44,6 +44,14 @@ RSpec.describe Integration, type: :model do
       end
     end
 
+    context 'when ticket_availability_in_minutes is zero' do
+      let(:integration) { create(:integration, ticket_availability_in_minutes: 0) }
+
+      it 'returns false' do
+        expect(integration.daily_availability?).to be_falsey
+      end
+    end
+
     context 'when ticket_availability_in_minutes is not present' do
       let(:integration) { create(:integration) }
 

--- a/spec/models/integration_spec.rb
+++ b/spec/models/integration_spec.rb
@@ -16,4 +16,40 @@ RSpec.describe Integration, type: :model do
       expect(integration.integration_address).to eq("https://dapp.ribon.io/integration/#{integration.unique_address}")
     end
   end
+
+  describe '#ticket_availability' do
+    context 'when ticket_availability_in_minutes is present' do
+      let(:integration) { create(:integration, ticket_availability_in_minutes: 10) }
+
+      it 'returns the ticket availability in minutes' do
+        expect(integration.ticket_availability).to eq('10 minutes')
+      end
+    end
+
+    context 'when ticket_availability_in_minutes is not present' do
+      let(:integration) { create(:integration) }
+
+      it 'returns the ticket availability in minutes' do
+        expect(integration.ticket_availability).to eq('Everyday at midnight')
+      end
+    end
+  end
+
+  describe '#daily_availability?' do
+    context 'when ticket_availability_in_minutes is present' do
+      let(:integration) { create(:integration, ticket_availability_in_minutes: 10) }
+
+      it 'returns false' do
+        expect(integration.daily_availability?).to be_falsey
+      end
+    end
+
+    context 'when ticket_availability_in_minutes is not present' do
+      let(:integration) { create(:integration) }
+
+      it 'returns true' do
+        expect(integration.daily_availability?).to be_truthy
+      end
+    end
+  end
 end

--- a/spec/requests/api/v1/integrations_spec.rb
+++ b/spec/requests/api/v1/integrations_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Api::V1::Integrations', type: :request do
       request
 
       expect_response_collection_to_have_keys(%w[created_at id updated_at name status unique_address
-                                                 integration_address integration_wallet])
+                                                 integration_address integration_wallet ticket_availability])
     end
   end
 
@@ -35,7 +35,7 @@ RSpec.describe 'Api::V1::Integrations', type: :request do
 
     it 'returns a single integration' do
       expect_response_to_have_keys(%w[created_at id updated_at name status unique_address integration_address
-                                      integration_wallet])
+                                      integration_wallet ticket_availability])
     end
   end
 
@@ -48,7 +48,7 @@ RSpec.describe 'Api::V1::Integrations', type: :request do
       request
 
       expect_response_to_have_keys(%w[created_at id updated_at name status unique_address integration_address
-                                      integration_wallet])
+                                      integration_wallet ticket_availability])
     end
   end
 


### PR DESCRIPTION
<!-- Delete any of those topics if they don't fit -->

# Description
- We need to store the ticket availability time for each integration

We're saving a single field called `ticket_availability_in_minutes` as a nullable integer
When it has a null value, we're assuming it's a Daily availability integration

We only have this logic at a database level. For the API response we are returning it in a fancier way:
![image](https://user-images.githubusercontent.com/24739860/183740394-d3480f4a-754b-48a2-bdcf-cd92a6206c21.png)
![image](https://user-images.githubusercontent.com/24739860/183740439-4ceb19b1-6b66-4f3d-a4b8-e10f9278a27c.png)

Our javascript frontends can handle it in the same way as a raw response.

I also did a little refactor in our create integration command.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] It is urgent
- [ ] <span style="color:#d44037">Dangerous change</span>
