### PR TITLE
fix: add to_sym to currency on person_payment

### DIFF
--- a/app/models/people/person_payment.rb
+++ b/app/models/people/person_payment.rb
@@ -47,7 +47,7 @@ class PersonPayment < ApplicationRecord
   private
 
   def currency
-    offer&.currency || :usd
+    offer&.currency&.to_sym&.downcase || :usd
   end
 
   def service_fees


### PR DESCRIPTION
<!-- Delete any of those topics if they don't fit -->

# Description
- Fixes person payment currency call

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] It is urgent
- [ ] <span style="color:#d44037">Dangerous change</span>
