### PR TITLE
feature: use UTC-3 as default timezone

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -48,6 +48,7 @@ module RibonCoreApi
     config.autoload_paths += Dir[Rails.root.join('app', 'models', '**/')]
     config.cache_store = :redis_cache_store, { url: RibonCoreApi.redis_url, namespace: "ribon_core_api:cache" }
     config.active_job.queue_adapter = :sidekiq
+    config.time_zone = 'Brasilia'
 
     config.api_only = true
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,4 +38,8 @@ RSpec.configure do |config|
     mocks.verify_partial_doubles = true
   end
   config.shared_context_metadata_behavior = :apply_to_host_groups
+
+  config.before(:suite) do
+    Time.zone = "UTC"
+  end
 end


### PR DESCRIPTION
<!-- Delete any of those topics if they don't fit -->

# Description
- We need to use UTC-3 (Brasilia timezone) as the default timezone 


Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] It is urgent
- [ ] <span style="color:#d44037">Dangerous change</span>
