### PR TITLE
feature: receive id or uuid as a parameter in the show method

### DIFF
--- a/app/controllers/api/v1/integrations_controller.rb
+++ b/app/controllers/api/v1/integrations_controller.rb
@@ -18,7 +18,7 @@ module Api
       end
 
       def show
-        @integration = Integration.find integration_params[:id]
+        @integration = Integration.find_by fetch_integration_query
 
         render json: IntegrationBlueprint.render(@integration)
       end
@@ -34,6 +34,14 @@ module Api
 
       def integration_params
         params.permit(:name, :status, :id, :ticket_availability_in_minutes)
+      end
+
+      def fetch_integration_query
+        uuid_regex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+
+        return { unique_address: integration_params[:id] } if uuid_regex.match?(integration_params[:id])
+
+        { id: integration_params[:id] }
       end
     end
   end

--- a/spec/requests/api/v1/integrations_spec.rb
+++ b/spec/requests/api/v1/integrations_spec.rb
@@ -41,15 +41,30 @@ RSpec.describe 'Api::V1::Integrations', type: :request do
   end
 
   describe 'GET /show' do
-    subject(:request) { get "/api/v1/integrations/#{integration.id}" }
+    context 'when id is numeric' do
+      subject(:request) { get "/api/v1/integrations/#{integration.id}" }
 
-    let(:integration) { create(:integration) }
+      let(:integration) { create(:integration) }
 
-    it 'returns a single integration' do
-      request
+      it 'returns a single integration' do
+        request
 
-      expect_response_to_have_keys(%w[created_at id updated_at name status unique_address integration_address
-                                      integration_wallet ticket_availability_in_minutes])
+        expect_response_to_have_keys(%w[created_at id updated_at name status unique_address integration_address
+                                        integration_wallet ticket_availability_in_minutes])
+      end
+
+      context 'when id is uuid' do
+        subject(:request) { get "/api/v1/integrations/#{integration.unique_address}" }
+
+        let(:integration) { create(:integration) }
+
+        it 'returns a single integration' do
+          request
+
+          expect_response_to_have_keys(%w[created_at id updated_at name status unique_address integration_address
+                                          integration_wallet ticket_availability_in_minutes])
+        end
+      end
     end
   end
 


### PR DESCRIPTION
<!-- Delete any of those topics if they don't fit -->

# Description
- We need to receive uuid as a parameter in the show method, in order to fetch integrations by uuid too

This is a temporary feature. We're looking forward to remove the numeric id, but before we need to talk about database rules

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] It is urgent
- [ ] <span style="color:#d44037">Dangerous change</span>
