### PR TITLE
chore: minimal seeds

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -11,4 +11,4 @@ unless Rails.env.production?
   puts 'Creating polygon chain...'
   Chain.create!(Web3::Providers::Networks::POLYGON)
   puts "Polygon chain created."
-endP
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -4,46 +4,11 @@ unless Rails.env.production?
                       default_chain_id: Web3::Providers::Networks::POLYGON[:chain_id])
   puts "Ribon Config created."
 
-  puts "Creating non profits..."
-  non_profit = NonProfit.first_or_create!(
-    name: "Non Profit",
-    wallet_address: "0x6E060041D62fDd76cF27c582f62983b864878E8F",
-    impact_description: "1 day of impact",
-  )
-
-  non_profit.non_profit_impacts.first_or_create!(usd_cents_to_one_impact_unit: 100,
-                                        start_date: "2022-01-01",
-                                        end_date: "2022-09-30")
-  puts "Non profits created."
-
-  puts "Creating integrations..."
-  integration = Integration.first_or_create!(
-    id: 3,
-    name: "Renner",
-    status: 'active',
-    unique_address: 'b3fa97fe-0302-4b00-97ba-df32e3060b74',
-    ticket_availability_in_minutes: 30,
-  )
-  puts "Integrations created."
-
-  puts "Creating integrations wallet..."
-  IntegrationWallet.first_or_create!(
-    public_key: "0x8927989eca54ece956e55416c92611fd3bc8dbc7",
-    encrypted_private_key: "SKnTRCyhF2Jry8miqAwokdOMo0pumX1VRseodY/8tM04HTc8ENL1OVEkJqXfz/1esi5z4orsCjatZMI3aZaisiUYXA07snVBtE1BVhbuQ+4=",
-    private_key_iv: "COGvFo2quFfnu0xnQMHeeQ==",
-    integration: integration,
-  )
-  puts "Integration wallet created."
-  
-  puts "Creating admin..."
-  Admin.first_or_create!(email: "admin@ribon.io", password: "admin123")
-  puts "Admin created."
-
-  puts "Creating test user..."
-  User.first_or_create!(email: "user@test.com")
-  puts "Test user created."
-
   puts "Creating mumbai chain..."
-  Chain.first_or_create!(Web3::Providers::Networks::POLYGON)
+  Chain.create!(Web3::Providers::Networks::MUMBAI)
   puts "Mumbai chain created."
-end
+
+  puts 'Creating polygon chain...'
+  Chain.create!(Web3::Providers::Networks::POLYGON)
+  puts "Polygon chain created."
+endP

--- a/lib/tasks/ribon/setup.rake
+++ b/lib/tasks/ribon/setup.rake
@@ -21,7 +21,7 @@ def setup_admin
   pf 'Admin password: '
   password = gets.chomp
 
-  Admin.create(email:, password:)
+  Admin.create!(email:, password:)
 
   puts "Admin with e-mail #{email} was created!"
 end

--- a/lib/tasks/ribon/setup.rake
+++ b/lib/tasks/ribon/setup.rake
@@ -3,7 +3,6 @@ namespace :ribon do
   task setup: :environment do
     puts 'Welcome to the Ribon Core API setup'
     puts 'Now we are going to create some customized entities.'
-    puts ''
 
     setup_admin
     setup_integration_and_wallet
@@ -32,13 +31,14 @@ def setup_integration_and_wallet
   pf 'Integration name: '
   name = gets.chomp
 
-  pf 'It is an active integration? (y/n) '
+  pf 'Integration is active? (y/n) '
   status = gets.chomp
 
   Integrations::CreateIntegration.call({ name:, status: status == 'y' ? 'active' : 'inactive' })
 
+  shortened_wallet = Integration.last.integration_wallet.public_key[0, 15].concat('...')
   puts "Integration #{name} was created!"
-  puts "The wallet #{Integration.last.integration_wallet.public_key} was associated to #{name}!"
+  puts "Integration wallet #{shortened_wallet} was associated to #{name}!"
 end
 
 def setup_non_profit
@@ -72,6 +72,7 @@ def setup_test_user
 end
 
 def can_create?(entity_name)
+  puts ''
   pf "Do you want to create a new #{entity_name}? (y/n) "
 
   gets.chomp.casecmp('y').zero?

--- a/lib/tasks/ribon/setup.rake
+++ b/lib/tasks/ribon/setup.rake
@@ -1,0 +1,100 @@
+desc 'This task helps the user to create some dummy data on local environment'
+namespace :ribon do
+  task setup: :environment do
+    puts 'Welcome to the Ribon Core API setup'
+    puts 'Now we are going to create some customized entities.'
+    puts ''
+
+    setup_admin
+    setup_integration_and_wallet
+    setup_non_profit
+    setup_test_user
+  end
+
+  def setup_admin
+    pf 'Do you want to create a new admin? (y/n) '
+    answer = gets.chomp
+
+    if answer.downcase == 'y'
+      pf 'Admin e-mail: '
+      email = gets.chomp
+
+      pf 'Admin password: '
+      password = gets.chomp
+
+      Admin.create(email:, password:)
+
+      puts "Admin with e-mail #{email} was created!"
+    end
+  end
+
+  def setup_integration_and_wallet
+    pf 'Do you want to create a new integration? (y/n) '
+    answer = gets.chomp
+
+    if answer.downcase == 'y'
+      pf 'Integration name: '
+      name = gets.chomp
+
+      pf 'It is an active integration? (y/n) '
+      status = gets.chomp
+
+      Integrations::CreateIntegration.call({name:, status: status == 'y' ? 'active' : 'inactive'})
+
+      puts "Integration #{name} was created!"
+      puts "The wallet #{Integration.last.integration_wallet.public_key} was associated to #{name}!"
+    end
+  end
+
+  def setup_non_profit
+    pf 'Do you want to create a new Non-profit? (y/n) '
+    answer = gets.chomp
+
+    if answer.downcase == 'y'
+      pf 'Non-profit name: '
+      name = gets.chomp
+
+      pf 'Non-profit wallet address: (default: 0x000...)'
+      wallet_address = gets.chomp
+
+      pf 'Non-profit impact description: (default: 1 day of impact)'
+      impact_description = gets.chomp
+
+      payload = {
+        name:,
+        wallet_address: wallet_address.present? ? wallet_address : '0x0000000000000000000000000000000000000000',
+        impact_description: impact_description.present? ? impact_description : '1 day of impact'
+      }
+
+      non_profit = NonProfit.create!(payload)
+
+      usd_cents_to_one_impact_unit = 100
+    
+      non_profit.non_profit_impacts.first_or_create!(usd_cents_to_one_impact_unit:,
+        start_date: "2022-01-01",
+        end_date: "2022-09-30")
+
+      puts "Non-profit #{name} was created!"
+      puts "A Non-profit impact with impact unit of USD #{usd_cents_to_one_impact_unit / 100} was created!"
+    end
+  end
+
+  def setup_test_user
+    pf 'Do you want to create a test user? (y/n) '
+    answer = gets.chomp
+
+    if answer.downcase == 'y'
+      pf 'User e-mail: '
+      email = gets.chomp
+      
+      User.create!(email:)
+
+      puts "User with email #{email} was created!"
+    end
+  end
+
+  def pf(str)
+    print str
+    $stdout.flush
+  end
+end

--- a/lib/tasks/ribon/setup.rake
+++ b/lib/tasks/ribon/setup.rake
@@ -50,10 +50,9 @@ def setup_non_profit
   pf 'Non-profit wallet address: (default: 0x000...)'
   wallet_address = gets.chomp
 
-  non_profit = NonProfit.create!({
-                                   name:, wallet_address: wallet_address.presence ||
-                                   '0x0000000000000000000000000000000000000000'
-                                 })
+  non_profit = NonProfit.create!(name:, wallet_address: wallet_address.presence ||
+                                '0x0000000000000000000000000000000000000000',
+                                 impact_description: '1 day of impact')
 
   non_profit.non_profit_impacts.first_or_create!(usd_cents_to_one_impact_unit: 100,
                                                  start_date: '2022-01-01', end_date: '2022-09-30')


### PR DESCRIPTION
<!-- Delete any of those topics if they don't fit -->

# Description
- Seeds can be useful when we need to bootstrap data. But in the Core-API we are using it to create entities that needs to be created by the developer and not the seed, like test integrations, non-profits, admin and test users

My proposition is to move these things to a separated rake task. In the seed we are just creating the base config and chains.
![image](https://user-images.githubusercontent.com/24739860/188359253-df0de03a-6b6e-40e7-9047-0a510ccb6e27.png)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] It is urgent
- [ ] <span style="color:#d44037">Dangerous change</span>
