### PR TITLE
Chore: blank string as SSL key for development

### DIFF
--- a/app/lib/web3/utils/cipher.rb
+++ b/app/lib/web3/utils/cipher.rb
@@ -31,7 +31,7 @@ module Web3
       end
 
       def self.secret_key
-        return String.new if Rails.env.development?
+        return '' if Rails.env.development?
 
         RibonCoreApi.config[:openssl][:ribon_secret_openssl_key]
       end

--- a/app/lib/web3/utils/cipher.rb
+++ b/app/lib/web3/utils/cipher.rb
@@ -1,8 +1,6 @@
 module Web3
   module Utils
     class Cipher
-      SECRET_KEY = RibonCoreApi.config[:openssl][:ribon_secret_openssl_key]
-
       def self.encrypt(plain_text)
         cipher     = cipher_instance.encrypt
         iv         = cipher.random_iv
@@ -29,7 +27,13 @@ module Web3
       end
 
       def self.sha256_key
-        ::Digest::SHA256.digest SECRET_KEY
+        ::Digest::SHA256.digest secret_key
+      end
+
+      def self.secret_key
+        return String.new if Rails.env.development?
+
+        RibonCoreApi.config[:openssl][:ribon_secret_openssl_key]
       end
     end
   end


### PR DESCRIPTION
<!-- Delete any of those topics if they don't fit -->

# Description
- To make it easier for developers and contributors to onboard, we are no longer using a robust SSL key for encryption, at least in the dev environment.


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] It is urgent
- [ ] <span style="color:#d44037">Dangerous change</span>
