### PR TITLE
fix: rubocop wrong namespaces

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,7 +21,7 @@ AllCops:
     - "app/lib/simple_command/**/*"
     - "app/controllers/rails_admin/**/*"
 
-Metrics/LineLength:
+Layout/LineLength:
   Max: 115
 
 Metrics/BlockLength:
@@ -40,16 +40,16 @@ Lint/AmbiguousBlockAssociation:
 Style/Documentation:
   Enabled: false
 
-Rspec/MultipleExpectations:
+RSpec/MultipleExpectations:
   Enabled: false
 
 RSpec/ExampleLength:
   Max: 10
 
-Rspec/PredicateMatcher:
+RSpec/PredicateMatcher:
   Enabled: false
 
-Rspec/NestedGroups:
+RSpec/NestedGroups:
   Max: 4
 
 Rails/HasManyOrHasOneDependent:


### PR DESCRIPTION
<!-- Delete any of those topics if they don't fit -->

# Description
- Some namespaces in the rubocop.yml rules are wrong and we need to fix it.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] It is urgent
- [ ] <span style="color:#d44037">Dangerous change</span>
