### PR TITLE
refactor: add donation_pool object as argument of ribon_contract methods

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -62,7 +62,7 @@ Rails/UniqueValidationWithoutIndex:
   Enabled: false
 
 RSpec/MultipleMemoizedHelpers:
-  Max: 8
+  Max: 10
 
 RSpec/NoExpectationExample:
   Enabled: false

--- a/app/commands/donations/create_blockchain_donation.rb
+++ b/app/commands/donations/create_blockchain_donation.rb
@@ -23,7 +23,7 @@ module Donations
       amount = ticket_value * CENTS_FACTOR
       non_profit_wallet_address = non_profit.wallet_address
 
-      ribon_contract.donate_through_integration(donation_pool_address:,
+      ribon_contract.donate_through_integration(donation_pool:,
                                                 non_profit_wallet_address:,
                                                 user: user.email, amount:, sender_key:)
     end
@@ -60,8 +60,8 @@ module Donations
       @user ||= donation.user
     end
 
-    def donation_pool_address
-      chain.default_donation_pool_address
+    def donation_pool
+      chain.default_donation_pool
     end
   end
 end

--- a/app/commands/givings/community_treasure/add_balance.rb
+++ b/app/commands/givings/community_treasure/add_balance.rb
@@ -12,7 +12,7 @@ module Givings
       end
 
       def call
-        ribon_contract.add_pool_balance(donation_pool_address:, amount:)
+        ribon_contract.add_pool_balance(donation_pool:, amount:)
       end
 
       private
@@ -21,8 +21,8 @@ module Givings
         @default_chain ||= Chain.default
       end
 
-      def donation_pool_address
-        default_chain.default_donation_pool_address
+      def donation_pool
+        default_chain.default_donation_pool
       end
 
       def ribon_contract

--- a/app/commands/integrations/create_integration.rb
+++ b/app/commands/integrations/create_integration.rb
@@ -42,10 +42,6 @@ module Integrations
       }
     end
 
-    def ribon_contract
-      @ribon_contract ||= Web3::Contracts::RibonContract.new(chain:)
-    end
-
     def chain
       @chain ||= Chain.default
     end

--- a/app/lib/web3/contracts/ribon_contract.rb
+++ b/app/lib/web3/contracts/ribon_contract.rb
@@ -1,10 +1,10 @@
 module Web3
   module Contracts
     class RibonContract < BaseContract
-      def add_pool_balance(donation_pool_address:, amount:)
-        parsed_amount = Utils::Converter.to_decimals(amount, 6) # TODO: convert according to token decimals
+      def add_pool_balance(donation_pool:, amount:)
+        parsed_amount = Utils::Converter.to_decimals(amount, donation_pool.token.decimals)
 
-        transact('addPoolBalance', donation_pool_address,
+        transact('addPoolBalance', donation_pool.address,
                  parsed_amount, sender_key: Providers::Keys::RIBON_KEY)
       end
 
@@ -15,13 +15,13 @@ module Web3
                  sender_key: Providers::Keys::RIBON_KEY)
       end
 
-      def donate_through_integration(donation_pool_address:, non_profit_wallet_address:, user:,
+      def donate_through_integration(donation_pool:, non_profit_wallet_address:, user:,
                                      amount:, sender_key:)
         keccak256_user = Utils::Converter.keccak(user)
-        parsed_amount = Utils::Converter.to_decimals(amount, 6) # TODO: convert according to token decimals
+        parsed_amount = Utils::Converter.to_decimals(amount, donation_pool.token.decimals)
         key = ::Eth::Key.new(priv: sender_key)
 
-        transact('donateThroughIntegration', donation_pool_address, non_profit_wallet_address,
+        transact('donateThroughIntegration', donation_pool.address, non_profit_wallet_address,
                  keccak256_user, parsed_amount, sender_key: key)
       end
 

--- a/app/models/blockchain/chain.rb
+++ b/app/models/blockchain/chain.rb
@@ -23,11 +23,16 @@ class Chain < ApplicationRecord
             :default_donation_pool_address, presence: true
 
   has_many :tokens, dependent: :destroy
+  has_many :pools, through: :tokens
 
   def self.default
     default_chain_id = RibonConfig.default_chain_id
 
     find_by(chain_id: default_chain_id)
+  end
+
+  def default_donation_pool
+    pools.find_by(address: default_donation_pool_address) || pools.first
   end
 
   def gas_fee(currency: :usd)

--- a/app/models/blockchain/token.rb
+++ b/app/models/blockchain/token.rb
@@ -14,4 +14,5 @@ class Token < ApplicationRecord
   validates :name, :address, :decimals, presence: true
 
   belongs_to :chain
+  has_many :pools
 end

--- a/spec/commands/givings/community_treasure/add_balance_spec.rb
+++ b/spec/commands/givings/community_treasure/add_balance_spec.rb
@@ -8,19 +8,19 @@ describe Givings::CommunityTreasure::AddBalance do
 
     let(:amount) { 0.5 }
     let(:ribon_contract) { instance_double(Web3::Contracts::RibonContract) }
-    let(:donation_pool_address) { '0xP000000000000000000000000000000000000000' }
+    let!(:chain) { create(:chain) }
+    let!(:donation_pool) { create(:pool, token: create(:token, chain:)) }
 
     before do
       allow(Web3::Contracts::RibonContract).to receive(:new).and_return(ribon_contract)
       allow(ribon_contract).to receive(:add_pool_balance)
-      create(:ribon_config)
-      create(:chain)
+      create(:ribon_config, default_chain_id: chain.chain_id)
     end
 
     it 'calls ribon contract add_pool_balance with correct args' do
       command
 
-      expect(ribon_contract).to have_received(:add_pool_balance).with(donation_pool_address:, amount:)
+      expect(ribon_contract).to have_received(:add_pool_balance).with(donation_pool:, amount:)
     end
   end
 end

--- a/spec/lib/web3/contracts/ribon_contract_spec.rb
+++ b/spec/lib/web3/contracts/ribon_contract_spec.rb
@@ -6,10 +6,11 @@ RSpec.describe Web3::Contracts::RibonContract do
   let(:contract) { OpenStruct.new({}) }
   let(:amount) { 0.5 }
   let(:user) { build(:user).email }
+  let(:donation_pool) { build(:pool) }
 
   describe '#add_pool_balance' do
     subject(:method_call) do
-      described_class.new(chain:).add_pool_balance(donation_pool_address: '0xFFFF', amount:)
+      described_class.new(chain:).add_pool_balance(donation_pool:, amount:)
     end
 
     before do
@@ -23,11 +24,10 @@ RSpec.describe Web3::Contracts::RibonContract do
       method_call
       wei_amount = Web3::Utils::Converter.to_decimals(amount, 6)
       sender_key = Web3::Providers::Keys::RIBON_KEY
-      donation_pool_address = '0xFFFF'
 
       expect(client)
         .to have_received(:transact).with(contract, 'addPoolBalance',
-                                          donation_pool_address, wei_amount,
+                                          donation_pool.address, wei_amount,
                                           gas_limit: 0, sender_key:)
     end
   end
@@ -58,14 +58,14 @@ RSpec.describe Web3::Contracts::RibonContract do
 
   describe '#donate_through_integration' do
     subject(:method_call) do
-      described_class.new(chain:)
-                     .donate_through_integration(donation_pool_address: '0xFFFF', amount:,
-                                                 user:, non_profit_wallet_address:, sender_key:)
+      described_class.new(chain:).donate_through_integration(donation_pool:, amount:, user:,
+                                                             non_profit_wallet_address:, sender_key:)
     end
 
     let(:non_profit_wallet_address) { build(:non_profit).wallet_address }
     let(:sender_key) { RibonCoreApi.config[:web3][:wallets][:ribon_wallet_private_key] }
     let(:key_struct) { OpenStruct.new({ private_key: sender_key }) }
+    let(:donation_pool) { build(:pool) }
 
     before do
       allow(Web3::Providers::Client).to receive(:create).and_return(client)
@@ -79,11 +79,10 @@ RSpec.describe Web3::Contracts::RibonContract do
       method_call
       wei_amount = Web3::Utils::Converter.to_decimals(amount, 6)
       keccak256_user = Web3::Utils::Converter.keccak(user)
-      donation_pool_address = '0xFFFF'
 
       expect(client)
         .to have_received(:transact).with(contract, 'donateThroughIntegration',
-                                          donation_pool_address, non_profit_wallet_address,
+                                          donation_pool.address, non_profit_wallet_address,
                                           keccak256_user, wei_amount, gas_limit: 0,
                                                                       sender_key: key_struct)
     end

--- a/spec/lib/web3/contracts/ribon_contract_spec.rb
+++ b/spec/lib/web3/contracts/ribon_contract_spec.rb
@@ -58,14 +58,14 @@ RSpec.describe Web3::Contracts::RibonContract do
 
   describe '#donate_through_integration' do
     subject(:method_call) do
-      described_class.new(chain:).donate_through_integration(donation_pool:, amount:, user:,
-                                                             non_profit_wallet_address:, sender_key:)
+      described_class.new(chain:).donate_through_integration(
+        donation_pool:, amount:, user:, non_profit_wallet_address:, sender_key:
+      )
     end
 
     let(:non_profit_wallet_address) { build(:non_profit).wallet_address }
     let(:sender_key) { RibonCoreApi.config[:web3][:wallets][:ribon_wallet_private_key] }
     let(:key_struct) { OpenStruct.new({ private_key: sender_key }) }
-    let(:donation_pool) { build(:pool) }
 
     before do
       allow(Web3::Providers::Client).to receive(:create).and_return(client)

--- a/spec/lib/web3/contracts/ribon_contract_spec.rb
+++ b/spec/lib/web3/contracts/ribon_contract_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe Web3::Contracts::RibonContract do
     before do
       allow(Web3::Providers::Client).to receive(:create).and_return(client)
       allow(::Eth::Contract).to receive(:from_abi).and_return(contract)
-      allow(client).to receive_messages(transact: {}, max_fee_per_gas: 0, max_priority_fee_per_gas: 0,
-                                        gas_limit: 0)
+      allow(client).to receive_messages(transact: {}, max_fee_per_gas: 0,
+                                        max_priority_fee_per_gas: 0, gas_limit: 0)
     end
 
     it 'calls the transact with correct args' do
@@ -26,9 +26,9 @@ RSpec.describe Web3::Contracts::RibonContract do
       sender_key = Web3::Providers::Keys::RIBON_KEY
 
       expect(client)
-        .to have_received(:transact).with(contract, 'addPoolBalance',
-                                          donation_pool.address, wei_amount,
-                                          gas_limit: 0, sender_key:)
+        .to have_received(:transact).with(
+          contract, 'addPoolBalance', donation_pool.address, wei_amount, gas_limit: 0, sender_key:
+        )
     end
   end
 
@@ -40,8 +40,8 @@ RSpec.describe Web3::Contracts::RibonContract do
     before do
       allow(Web3::Providers::Client).to receive(:create).and_return(client)
       allow(::Eth::Contract).to receive(:from_abi).and_return(contract)
-      allow(client).to receive_messages(transact: {}, max_fee_per_gas: 0, max_priority_fee_per_gas: 0,
-                                        gas_limit: 0)
+      allow(client).to receive_messages(transact: {}, max_fee_per_gas: 0,
+                                        max_priority_fee_per_gas: 0, gas_limit: 0)
     end
 
     it 'calls the transact with correct args' do
@@ -50,9 +50,9 @@ RSpec.describe Web3::Contracts::RibonContract do
       sender_key = Web3::Providers::Keys::RIBON_KEY
 
       expect(client)
-        .to have_received(:transact).with(contract, 'addIntegrationBalance',
-                                          integration_address, wei_amount,
-                                          gas_limit: 0, sender_key:)
+        .to have_received(:transact).with(
+          contract, 'addIntegrationBalance', integration_address, wei_amount, gas_limit: 0, sender_key:
+        )
     end
   end
 
@@ -81,10 +81,10 @@ RSpec.describe Web3::Contracts::RibonContract do
       keccak256_user = Web3::Utils::Converter.keccak(user)
 
       expect(client)
-        .to have_received(:transact).with(contract, 'donateThroughIntegration',
-                                          donation_pool.address, non_profit_wallet_address,
-                                          keccak256_user, wei_amount, gas_limit: 0,
-                                                                      sender_key: key_struct)
+        .to have_received(:transact).with(
+          contract, 'donateThroughIntegration', donation_pool.address, non_profit_wallet_address,
+          keccak256_user, wei_amount, gas_limit: 0, sender_key: key_struct
+        )
     end
   end
 end

--- a/spec/models/chain_spec.rb
+++ b/spec/models/chain_spec.rb
@@ -51,4 +51,27 @@ RSpec.describe Chain, type: :model do
       expect(fee_instance).to have_received(:estimate_fee)
     end
   end
+
+  describe '#default_pool' do
+    let(:chain) { create(:chain, default_donation_pool_address:) }
+    let(:token) { create(:token, chain:) }
+    let!(:pool1) { create(:pool, token:, address: '0xP001') }
+    let!(:pool2) { create(:pool, token:, address: '0xP002') }
+
+    context 'when there is a default_donation_pool_address' do
+      let(:default_donation_pool_address) { '0xP002' }
+
+      it 'returns the pool with that address' do
+        expect(chain.default_donation_pool).to eq(pool2)
+      end
+    end
+
+    context 'when there is no default_donation_pool_address' do
+      let(:default_donation_pool_address) { '0x0' }
+
+      it 'returns the first pool' do
+        expect(chain.default_donation_pool).to eq(pool1)
+      end
+    end
+  end
 end


### PR DESCRIPTION
<!-- Delete any of those topics if they don't fit -->

# Description
- Add decimals to ribon contract methods

This PR makes use of the token and pool models to correctly format the amount of decimals when requesting a donation / giving on the blockchain

# Things to change
- Create tokens in all envs (dev, staging and prod) [x]
- Create pools in all envs (dev, staging and prod) [x]
## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] It is urgent
- [ ] <span style="color:#d44037">Dangerous change</span>
