### PR TITLE
refactor: makes impact end date optional

### DIFF
--- a/app/models/non_profits/non_profit_impact.rb
+++ b/app/models/non_profits/non_profit_impact.rb
@@ -13,7 +13,7 @@
 class NonProfitImpact < ApplicationRecord
   belongs_to :non_profit
 
-  validates :usd_cents_to_one_impact_unit, :start_date, :end_date, presence: true
+  validates :usd_cents_to_one_impact_unit, :start_date, presence: true
 
   def impact_by_ticket
     (RibonConfig.default_ticket_value / usd_cents_to_one_impact_unit).to_i

--- a/spec/models/non_profit_impact_spec.rb
+++ b/spec/models/non_profit_impact_spec.rb
@@ -19,7 +19,6 @@ RSpec.describe NonProfitImpact, type: :model do
     it { is_expected.to belong_to(:non_profit) }
     it { is_expected.to validate_presence_of(:usd_cents_to_one_impact_unit) }
     it { is_expected.to validate_presence_of(:start_date) }
-    it { is_expected.to validate_presence_of(:end_date) }
   end
 
   describe '#impact_by_ticket' do


### PR DESCRIPTION
# Description
- Makes end date attribute optional for non profits impact

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] It is urgent
- [ ] <span style="color:#d44037">Dangerous change</span>
