### PR TITLE
fix: update refund date on webhook

### DIFF
--- a/app/controllers/webhooks/stripe_controller.rb
+++ b/app/controllers/webhooks/stripe_controller.rb
@@ -21,22 +21,27 @@ module Webhooks
       RibonCoreApi.config[:stripe][:endpoint_secret]
     end
 
-    def update_status(external_id, status)
-      PersonPayment.where(external_id:).last&.update(status:)
-    end
-
     def event_handler(event)
       result = event.data.object
       external_id = result['payment_intent']
       case event.type
       when 'charge.refunded'
         update_status(external_id, 'refunded') if external_id
+        update_date(external_id, Time.zone.at(result[:created])) if external_id
       when 'charge.refund.updated'
         update_status(external_id, 'refund_failed') if external_id
       else
         Rails.logger.info { "Unhandled event type: #{event.type}" }
       end
       nil
+    end
+
+    def update_status(external_id, status)
+      PersonPayment.where(external_id:).last&.update(status:)
+    end
+
+    def update_date(external_id, refund_date)
+      PersonPayment.where(external_id:).last&.update(refund_date:)
     end
   end
 end

--- a/spec/requests/webhooks/stripe_controller_spec.rb
+++ b/spec/requests/webhooks/stripe_controller_spec.rb
@@ -36,6 +36,12 @@ RSpec.describe 'Webhooks::Stripe', type: :request do
           request
           expect(person_payment.reload.status).to eq('refunded')
         end
+
+        it 'updates the refund_date of person payment' do
+          request
+          expect(person_payment.reload.refund_date).to eq(Time.zone.at(event_params.dig('data', 'object',
+                                                                                        'created')))
+        end
       end
 
       context 'when it is a charge refund update type request' do
@@ -47,6 +53,10 @@ RSpec.describe 'Webhooks::Stripe', type: :request do
         it 'updates the status of person payment' do
           request
           expect(person_payment.reload.status).to eq('refund_failed')
+        end
+
+        it 'do not update the refund_date of person payment' do
+          expect { request }.not_to change(person_payment, :refund_date)
         end
       end
     end

--- a/spec/support/webhooks/stripe/refund_update.json
+++ b/spec/support/webhooks/stripe/refund_update.json
@@ -7,7 +7,8 @@
     "object": {
       "id": "ch_3LwqQFJuOnwQq9Qx173xACg7",
       "object": "charge",
-      "payment_intent": "pi_123456"
+      "payment_intent": "pi_123456",
+      "created": 1666700440
     }
   },
   "livemode": false,

--- a/spec/support/webhooks/stripe/refunded.json
+++ b/spec/support/webhooks/stripe/refunded.json
@@ -7,7 +7,8 @@
     "object": {
       "id": "ch_3LwqQFJuOnwQq9Qx173xACg7",
       "object": "charge",
-      "payment_intent": "pi_123456"
+      "payment_intent": "pi_123456",
+      "created": 1666700440
     }
   },
   "livemode": false,


### PR DESCRIPTION
<!-- Delete any of those topics if they don't fit -->

# Description

- I forgor to update refund date on webhook charge.refunded

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dangerous changes
- [ ] Chore (change that does not effect how the code works, eg: change color)
- [ ] Tests

## How to test

Put here all the things need to test this PR and verify your changes, also list any relevant details for tests (eg: have a wallet)

- Make a refund on stripe and see if the refund date has been updated