### PR TITLE
refactor: update RequestApi to return HTTParty response

### DIFF
--- a/app/jobs/vouchers/webhook_job.rb
+++ b/app/jobs/vouchers/webhook_job.rb
@@ -6,7 +6,7 @@ module Vouchers
       response = Request::ApiRequest.post(voucher.integration.webhook_url,
                                           body: VoucherBlueprint.render(voucher))
 
-      raise Exceptions::VoucherWebhookError, 'webhook failed' if response.status != 200
+      raise Exceptions::VoucherWebhookError, 'webhook failed' unless response.ok?
     end
   end
 end

--- a/app/lib/currency/rates.rb
+++ b/app/lib/currency/rates.rb
@@ -13,7 +13,7 @@ module Currency
 
     def rate
       response = Request::ApiRequest.get(request_url, expires_in: 2.hours)
-      response["#{from.upcase}#{to.upcase}"].ask
+      response["#{from.upcase}#{to.upcase}"]['ask']
     end
 
     private

--- a/app/lib/request/api_request.rb
+++ b/app/lib/request/api_request.rb
@@ -1,18 +1,14 @@
 module Request
   class ApiRequest
     def self.get(url, expires_in: nil)
-      response = RedisStore::Cache.find_or_create(key: url.parameterize, expires_in:) do
+      RedisStore::Cache.find_or_create(key: url.parameterize, expires_in:) do
         HTTParty.get(url)
       end
-
-      RecursiveOpenStruct.new(response)
     end
 
     def self.post(url, body:, headers: {})
       default_headers = { 'Content-Type' => 'application/json' }
-      response = HTTParty.post(url, body:, headers: default_headers.merge(headers))
-
-      RecursiveOpenStruct.new(response)
+      HTTParty.post(url, body:, headers: default_headers.merge(headers))
     end
   end
 end

--- a/app/lib/web3/utils/fee.rb
+++ b/app/lib/web3/utils/fee.rb
@@ -10,7 +10,7 @@ module Web3
 
       def estimate_fee
         request = Request::ApiRequest.get(chain.gas_fee_url, expires_in: 2.hours)
-        gas_fee_in_usd = request.speeds.second['estimatedFee']
+        gas_fee_in_usd = request['speeds'].second['estimatedFee']
 
         formatted_gas_fee(gas_fee_in_usd)
       end

--- a/app/lib/web3/utils/gas.rb
+++ b/app/lib/web3/utils/gas.rb
@@ -12,7 +12,7 @@ module Web3
 
       def estimate_gas
         request = Request::ApiRequest.get("#{chain.gas_fee_url}?eip1559=true", expires_in: 2.hours)
-        speeds = request.speeds.second
+        speeds = request['speeds'].second
 
         max_fee_per_gas = [speeds['maxFeePerGas'], DEFAULT_MAX_FEE_PER_GAS].min
         max_priority_fee_per_gas = [speeds['maxPriorityFeePerGas'], DEFAULT_MAX_FEE_PER_GAS].min

--- a/app/services/service/givings/fees/crypto/polygon_fee_calculator.rb
+++ b/app/services/service/givings/fees/crypto/polygon_fee_calculator.rb
@@ -12,7 +12,7 @@ module Service
 
           def calculate_fee
             request = Request::ApiRequest.get(polygon_fee_url, expires_in: 2.hours)
-            gas_fee_in_usd = request.speeds.first['estimatedFee']
+            gas_fee_in_usd = request['speeds'].first['estimatedFee']
 
             formatted_gas_fee(gas_fee_in_usd).round
           end

--- a/spec/jobs/vouchers/webhook_job_spec.rb
+++ b/spec/jobs/vouchers/webhook_job_spec.rb
@@ -9,11 +9,11 @@ RSpec.describe Vouchers::WebhookJob, type: :job do
     let(:integration_webhook) { build(:integration_webhook, url: 'http://example.url') }
 
     before do
-      allow(Request::ApiRequest).to receive(:post).and_return(OpenStruct.new({ status: }))
+      allow(Request::ApiRequest).to receive(:post).and_return(OpenStruct.new({ ok?: ok }))
     end
 
     context 'when the request returns a response success' do
-      let(:status) { 200 }
+      let(:ok) { true }
 
       it 'calls the api request with correct params' do
         perform_job
@@ -24,7 +24,7 @@ RSpec.describe Vouchers::WebhookJob, type: :job do
     end
 
     context 'when the request returns a response failure' do
-      let(:status) { 404 }
+      let(:ok) { false }
 
       it 'raises a webhook failed error' do
         expect { perform_job }.to raise_error(StandardError, 'webhook failed')

--- a/spec/lib/request/api_request_spec.rb
+++ b/spec/lib/request/api_request_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Request::ApiRequest do
     let(:url) { 'http://test.url' }
     let(:response_json) do
       {
-        some_key: 'value'
+        'some_key' => 'value'
       }
     end
 
@@ -22,7 +22,7 @@ RSpec.describe Request::ApiRequest do
     end
 
     it 'formats the request as an openstruct' do
-      expect(request.some_key).to eq 'value'
+      expect(request['some_key']).to eq 'value'
     end
   end
 
@@ -32,7 +32,7 @@ RSpec.describe Request::ApiRequest do
     let(:url) { 'http://test.url' }
     let(:response_json) do
       {
-        some_key: 'value'
+        'some_key' => 'value'
       }
     end
     let(:body) do
@@ -56,7 +56,7 @@ RSpec.describe Request::ApiRequest do
     end
 
     it 'formats the request as an openstruct' do
-      expect(request.some_key).to eq 'value'
+      expect(request['some_key']).to eq 'value'
     end
   end
 end


### PR DESCRIPTION
<!-- Delete any of those topics if they don't fit -->

# Description

- Update RequestApi to return HTTParty response

We were parsing the response with RecursiveOpenStruct, but this ends up loosing some info of the HTTParty response such as the status, which we will need now.
Also, if the response was an HTML or nil, it would broke. In this way we always have the response as a json that HTTParty returns and we can use it normally.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dangerous changes
- [ ] Chore (change that does not effect how the code works, eg: change color)
- [ ] Tests

## How to test

Put here all the things need to test this PR and verify your changes, also list any relevant details for tests (eg: have a wallet)

- Test A
