### PR TITLE
fix: add skip_allowance to Donation command to allow voucher donations

### DIFF
--- a/app/commands/donations/donate.rb
+++ b/app/commands/donations/donate.rb
@@ -3,13 +3,14 @@
 module Donations
   class Donate < ApplicationCommand
     prepend SimpleCommand
-    attr_reader :non_profit, :integration, :donation, :user, :platform
+    attr_reader :non_profit, :integration, :donation, :user, :platform, :skip_allowance
 
-    def initialize(integration:, non_profit:, user:, platform:)
+    def initialize(integration:, non_profit:, user:, platform:, skip_allowance: false)
       @integration = integration
       @non_profit = non_profit
       @user = user
       @platform = platform
+      @skip_allowance = skip_allowance
     end
 
     def call
@@ -51,7 +52,7 @@ module Donations
     end
 
     def allowed?
-      return true if user.can_donate?(integration)
+      return true if user.can_donate?(integration) || skip_allowance
 
       errors.add(:message, I18n.t('donations.blocked_message'))
 

--- a/app/controllers/api/v1/vouchers/donations_controller.rb
+++ b/app/controllers/api/v1/vouchers/donations_controller.rb
@@ -35,7 +35,7 @@ module Api
         end
 
         def donation_command
-          ::Donations::Donate.new(integration:, non_profit:, user:, platform:)
+          ::Donations::Donate.new(integration:, non_profit:, user:, platform:, skip_allowance: true)
         end
 
         def donation_params

--- a/spec/services/service/donations/statistics_spec.rb
+++ b/spec/services/service/donations/statistics_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Service::Donations::Statistics, type: :service do
   let(:non_profit2) { create(:non_profit) }
 
   before do
-    travel_to Time.zone.local(2023, 1, 1, 12, 12, 30)
+    travel_to Time.zone.local(2023, 1, 1, 12, 0, 0)
 
     create(:non_profit_impact, usd_cents_to_one_impact_unit: 10,
                                non_profit: non_profit1, start_date: 1.day.ago, end_date: 1.day.from_now)

--- a/spec/services/service/donations/statistics_spec.rb
+++ b/spec/services/service/donations/statistics_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Service::Donations::Statistics, type: :service do
   let(:non_profit2) { create(:non_profit) }
 
   before do
-    travel_to Time.zone.local(2023, 1, 1, 12, 0, 0)
+    travel_to Time.zone.local(2023, 1, 1, 12, 12, 30)
 
     create(:non_profit_impact, usd_cents_to_one_impact_unit: 10,
                                non_profit: non_profit1, start_date: 1.day.ago, end_date: 1.day.from_now)


### PR DESCRIPTION
<!-- Delete any of those topics if they don't fit -->

# Description

- Add `skip_allowance` attribute to Donation Command to allow voucher donations, since they are always allowed by default, regarding the user that is using the voucher
## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dangerous changes
- [ ] Chore (change that does not effect how the code works, eg: change color)
- [ ] Tests

## How to test

Put here all the things need to test this PR and verify your changes, also list any relevant details for tests (eg: have a wallet)

- Test A
