### PR TITLE
fix: pass cause object instead of name

### DIFF
--- a/app/blueprints/person_payment_blueprint.rb
+++ b/app/blueprints/person_payment_blueprint.rb
@@ -37,7 +37,7 @@ class PersonPaymentBlueprint < Blueprinter::Base
     end
 
     field :cause do |payment|
-      payment.receiver&.name
+      payment.receiver
     end
   end
 end


### PR DESCRIPTION
# Description

- Passes entire cause object since we also need the cause id on the front end

