### PR TITLE
feat: adds legacy_id on users table

### DIFF
--- a/app/models/users/user.rb
+++ b/app/models/users/user.rb
@@ -7,6 +7,7 @@
 #  language   :integer          default("en")
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  legacy_id  :integer
 #
 class User < ApplicationRecord
   validates :email, uniqueness: { case_sensitive: true }, format: { with: URI::MailTo::EMAIL_REGEXP }

--- a/db/migrate/20230418154736_add_legacy_id_to_users.rb
+++ b/db/migrate/20230418154736_add_legacy_id_to_users.rb
@@ -1,0 +1,5 @@
+class AddLegacyIdToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :legacy_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_18_125247) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_18_154736) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -516,6 +516,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_18_125247) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "language", default: 0
+    t.integer "legacy_id"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -7,6 +7,7 @@
 #  language   :integer          default("en")
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  legacy_id  :integer
 #
 FactoryBot.define do
   factory :user do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -7,6 +7,7 @@
 #  language   :integer          default("en")
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  legacy_id  :integer
 #
 require 'rails_helper'
 


### PR DESCRIPTION
# Description

- Now that we're making a web2 migration, we need to have access to the web2 id, so I added it as 'legacy id' here

# Necessary changes

- run db:migrate

## Does this pull request close any open issues?

- [#tech-421](https://ribon.atlassian.net/browse/TECH-421?atlOrigin=eyJpIjoiOGYyMmM3ZjA4MDZiNGI1Yzk2MDQwNGQ4ZDVkZTM2ZTciLCJwIjoiaiJ9)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dangerous changes
- [x] Chore (change that does not effect how the code works, eg: change color)
- [ ] Tests