### PR TITLE
fix: add rescue to non profit logo attaching in legacy

### DIFF
--- a/app/commands/legacy/create_legacy_user_impact.rb
+++ b/app/commands/legacy/create_legacy_user_impact.rb
@@ -70,6 +70,8 @@ module Legacy
       file = URI.open(url)
       # rubocop:enable Security/Open
       non_profit.logo.attach(io: file, filename:)
+    rescue StandardError => e
+      Rails.logger.error "Error attaching logo to non profit #{non_profit&.name}: #{e}"
     end
 
     def update_current_id(legacy_non_profit)


### PR DESCRIPTION
<!-- Delete any of those topics if they don't fit -->

# Description

- Add a rescue if the logo is not attached
This will prevent the impact from not being saved. We can attach manually logos that eventually did not attach correctly

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dangerous changes
- [ ] Chore (change that does not effect how the code works, eg: change color)
- [ ] Tests

## How to test

Put here all the things need to test this PR and verify your changes, also list any relevant details for tests (eg: have a wallet)

- Test A
