### PR TITLE
build: update ssl options to health check

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -15,6 +15,11 @@ Rails.application.configure do
   config.log_formatter = ::Logger::Formatter.new
   config.active_job.queue_adapter = :sidekiq
   config.force_ssl = true
+  config.ssl_options = {
+    redirect: {
+      exclude: -> request { request.path =~ /health/ }
+    }
+  }
 
   Rails.application.reloader.to_prepare do
     Dir["#{Rails.root}/app/models/rule_groups/*.rb"].each { |file| require_dependency file }


### PR DESCRIPTION
<!-- Delete any of those topics if they don't fit -->

# Description

- Exclude healthcheck path from forced ssl
Elastic beanstalk is not able to healthcheck a path using ssl enforcment. We need this redirect

![image](https://github.com/RibonDAO/core-api/assets/27820474/febf5981-16f4-4a2e-a555-320c4dbd18e7)

Our envs are currently on severe because the health check cannot complete (dev now is OK with this PR), but they are working just fine
## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dangerous changes
- [ ] Chore (change that does not effect how the code works, eg: change color)
- [ ] Tests

## How to test

Put here all the things need to test this PR and verify your changes, also list any relevant details for tests (eg: have a wallet)

- Test A
