### PR TITLE
refactor: update token issued at to get first token from authenticatable

### DIFF
--- a/app/models/concerns/authenticatable_model.rb
+++ b/app/models/concerns/authenticatable_model.rb
@@ -8,6 +8,6 @@ module AuthenticatableModel
   end
 
   def token_issued_at
-    refresh_tokens.last&.created_at
+    refresh_tokens.first&.created_at
   end
 end


### PR DESCRIPTION
<!-- Delete any of those topics if they don't fit -->

# Description

- Refactor token issue at to be referent to the first refresh token

The authenticatable can have multiple refresh tokens (for example, it logs in from web and from a mobile app). In this case, both should be valid, having as reference the first refresh token date
# Necessary changes

- Put here any changes that must be done when this PR is merged
- eg: update an environment variable

## Does this pull request close any open issues?

- Put here the issue that must be closed with this PR
- eg: closes [#001]()

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dangerous changes
- [ ] Chore (change that does not effect how the code works, eg: change color)
- [ ] Tests

## How to test

Put here all the things need to test this PR and verify your changes, also list any relevant details for tests (eg: have a wallet)

- Test A
