### PR TITLE
fix: add service to delete contribution_fee

### DIFF
--- a/app/commands/contributions/increase_contribution_balance_fee.rb
+++ b/app/commands/contributions/increase_contribution_balance_fee.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Contributions
+  class IncreaseContributionBalanceFee < ApplicationCommand
+    prepend SimpleCommand
+
+    attr_reader :contribution_balance, :fee_cents
+
+    def initialize(contribution_balance:, fee_cents:)
+      @contribution_balance = contribution_balance
+      @fee_cents = fee_cents
+    end
+
+    def call
+      contribution_balance.fees_balance_cents += fee_cents
+      contribution_balance.save
+    end
+  end
+end

--- a/app/services/service/contributions/contribution_fee_delete_service.rb
+++ b/app/services/service/contributions/contribution_fee_delete_service.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Service
+  module Contributions
+    class ContributionFeeDeleteService
+      attr_reader :contribution_fee
+
+      def initialize(contribution_fee:)
+        @contribution_fee = contribution_fee
+      end
+
+      def handle_fee_delete
+        delete_contribution_fee
+        update_contribution_balance
+      rescue StandardError => e
+        Reporter.log(error: e)
+      end
+
+      private
+
+      def update_contribution_balance
+        ::Contributions::IncreaseContributionBalanceFee.call(contribution_balance:, fee_cents:)
+      end
+
+      def delete_contribution_fee
+        @contribution_fee = contribution_fee.destroy
+      end
+
+      def contribution_balance
+        contribution_fee.payer_contribution.contribution_balance
+      end
+
+      def fee_cents
+        contribution_fee.fee_cents
+      end
+    end
+  end
+end

--- a/spec/commands/contributions/increase_contribution_balance_fee_spec.rb
+++ b/spec/commands/contributions/increase_contribution_balance_fee_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Contributions::IncreaseContributionBalanceFee do
+  subject(:command) { described_class.call(contribution_balance:, fee_cents:) }
+
+  let(:fees_balance_cents) { 10 }
+  let(:contribution_balance) { create(:contribution_balance, fees_balance_cents:) }
+  let(:fee_cents) { 1 }
+
+  describe '#call' do
+    it 'increases the fees_balance_cents' do
+      command
+      expect(contribution_balance.reload.fees_balance_cents).to eq(11)
+    end
+  end
+end

--- a/spec/factories/contribution_fees.rb
+++ b/spec/factories/contribution_fees.rb
@@ -13,7 +13,7 @@
 FactoryBot.define do
   factory :contribution_fee do
     association :contribution, factory: :contribution
-    payer_contribution { nil }
+    payer_contribution { build(:contribution) }
     fee_cents { 1 }
   end
 end

--- a/spec/services/service/contributions/contribution_fee_delete_service_spec.rb
+++ b/spec/services/service/contributions/contribution_fee_delete_service_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Service::Contributions::ContributionFeeDeleteService, type: :service do
+  subject(:service) do
+    described_class.new(
+      contribution_fee:
+    )
+  end
+
+  let(:contribution) { create(:contribution, :with_contribution_balance) }
+  let(:payer_contribution) { create(:contribution, :with_contribution_balance) }
+  let(:contribution_fee) { create(:contribution_fee, contribution:, payer_contribution:) }
+
+  describe '#handle_fee_delete' do
+    before do
+      allow(::Contributions::IncreaseContributionBalanceFee).to receive(:call)
+    end
+
+    it 'delete a contribution fee' do
+      expect { service.handle_fee_delete }.not_to change(ContributionFee, :count)
+    end
+
+    it 'updates the contribution balance' do
+      service.handle_fee_delete
+
+      expect(::Contributions::IncreaseContributionBalanceFee).to have_received(:call).with(
+        contribution_balance: payer_contribution.contribution_balance,
+        fee_cents: contribution_fee.fee_cents
+      )
+    end
+  end
+end


### PR DESCRIPTION
<!-- Delete any of those topics if they don't fit -->

# Description

- this service is necessary because we need to delete a contribution fee and create a new one so our database is equal to what happened on blockchain. Contribution 514 was supposed to be created before contribution 505.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Dangerous changes
- [ ] Chore (change that does not effect how the code works, eg: change color)
- [ ] Tests

## How to test

Put here all the things need to test this PR and verify your changes, also list any relevant details for tests (eg: have a wallet)

- Test A
