### PR TITLE
feat: add default address to stripe

### DIFF
--- a/app/lib/payment/gateways/stripe/entities/customer.rb
+++ b/app/lib/payment/gateways/stripe/entities/customer.rb
@@ -3,15 +3,24 @@ module Payment
     module Stripe
       module Entities
         class Customer
-          def self.create(customer:, payment_method:)
+          def self.create(customer:, payment_method:, address: default_address)
             ::Stripe::Customer.create({
                                         email: customer&.email,
                                         name: customer&.name,
                                         payment_method: payment_method&.id,
                                         invoice_settings: {
                                           default_payment_method: payment_method&.id
-                                        }
+                                        },
+                                        address:
                                       })
+          end
+
+          def self.default_address
+            {
+              country: 'BR',
+              city: 'Brasília',
+              state: 'DF'
+            }
           end
         end
       end

--- a/app/lib/payment/gateways/stripe/entities/customer.rb
+++ b/app/lib/payment/gateways/stripe/entities/customer.rb
@@ -15,6 +15,7 @@ module Payment
                                       })
           end
 
+          # TODO: Update pix, stores and credit_cards controller to pass the address on customer creation
           def self.default_address
             {
               country: 'BR',

--- a/spec/lib/payment/gateways/stripe/entities/customer_spec.rb
+++ b/spec/lib/payment/gateways/stripe/entities/customer_spec.rb
@@ -16,7 +16,8 @@ RSpec.describe Payment::Gateways::Stripe::Entities::Customer do
         payment_method: payment_method.id,
         invoice_settings: {
           default_payment_method: payment_method.id
-        }
+        },
+        address: described_class.default_address
       }
     end
 


### PR DESCRIPTION
<!-- Delete any of those topics if they don't fit -->

# Description

- Add default address to stripe
This will allow us to not ask for the address of the user.
We discussed with the financial team and that is not needed to make the fiscal notes

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Dangerous changes
- [ ] Chore (change that does not effect how the code works, eg: change color)
- [ ] Tests

## How to test

Put here all the things need to test this PR and verify your changes, also list any relevant details for tests (eg: have a wallet)

- Test A
