### PR TITLE
feat: adds articles_since_user_creation method

### DIFF
--- a/app/controllers/api/v1/news/articles_controller.rb
+++ b/app/controllers/api/v1/news/articles_controller.rb
@@ -32,6 +32,13 @@ module Api
           end
         end
 
+        def articles_since_user_creation
+          @articles = articles_list.where('published_at > ?',
+                                          current_user&.created_at).order(sortable).page(page).per(per)
+
+          render json: ArticleBlueprint.render(@articles, total_items:, page:, total_pages:)
+        end
+
         private
 
         def articles_list

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -86,6 +86,7 @@ Rails.application.routes.draw do
         get 'articles/:id' => 'articles#show'
         post 'articles' => 'articles#create'
         put 'articles/:id' => 'articles#update'
+        get 'articles_since_user_creation' => 'articles#articles_since_user_creation'
 
         get 'authors' => 'authors#index'
         get 'authors/:id' => 'authors#show'


### PR DESCRIPTION
# Description

- Adds a method to filter the news for only showing the articles created after the user was created

## Does this pull request close any open issues?

- [#prod3-127](https://ribon.atlassian.net/browse/PROD3-127?atlOrigin=eyJpIjoiZTU1NzhkN2VkOTAzNDUwMGJmYmE0MjEwY2ViODE0ZjIiLCJwIjoiaiJ9)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Dangerous changes
- [ ] Chore (change that does not effect how the code works, eg: change color)
- [ ] Tests

## How to test

- Try with users created at different days
