### PR TITLE
fix: update labeling to get cause instead of receiver

### DIFF
--- a/app/models/configs/ribon_config.rb
+++ b/app/models/configs/ribon_config.rb
@@ -5,6 +5,7 @@
 #  id                                        :bigint           not null, primary key
 #  contribution_fee_percentage               :decimal(, )
 #  default_ticket_value                      :decimal(, )
+#  disable_labeling                          :boolean          default(FALSE)
 #  minimum_contribution_chargeable_fee_cents :integer
 #  created_at                                :datetime         not null
 #  updated_at                                :datetime         not null
@@ -32,6 +33,10 @@ class RibonConfig < ApplicationRecord
 
   def self.default_chain_id
     first&.default_chain_id
+  end
+
+  def self.disable_labeling
+    first&.disable_labeling
   end
 
   private

--- a/app/models/contributions/contribution.rb
+++ b/app/models/contributions/contribution.rb
@@ -96,4 +96,10 @@ class Contribution < ApplicationRecord
 
     receiver&.non_profits
   end
+
+  def cause
+    return receiver if receiver_type == 'Cause'
+
+    receiver.cause
+  end
 end

--- a/app/queries/contribution_queries.rb
+++ b/app/queries/contribution_queries.rb
@@ -13,7 +13,7 @@ class ContributionQueries
       .with_paid_status
       .confirmed_on_blockchain_before(contribution.person_payment.person_blockchain_transaction.succeeded_at)
       .where.not(contribution_id: contribution.id)
-      .joins(:contribution).where(contributions: { receiver: contribution.receiver })
+      .joins(:contribution).where(contributions: { receiver: contribution.cause })
       .order(fees_balance_cents: :asc)
   end
 
@@ -23,7 +23,7 @@ class ContributionQueries
       .with_paid_status
       .confirmed_on_blockchain_before(contribution.person_payment.person_blockchain_transaction.succeeded_at)
       .where.not(contribution_id: contribution.id)
-      .joins(:contribution).where(contributions: { receiver: contribution.receiver })
+      .joins(:contribution).where(contributions: { receiver: contribution.cause })
       .order(tickets_balance_cents: :asc)
   end
 

--- a/app/services/service/contributions/fees_labeling_service.rb
+++ b/app/services/service/contributions/fees_labeling_service.rb
@@ -10,6 +10,7 @@ module Service
       end
 
       def spread_fee_to_payers
+        return if RibonConfig.disable_labeling
         return if contribution.already_spread_fees?
 
         @initial_contributions_balance = feeable_contribution_balances.sum(&:fees_balance_cents)

--- a/app/services/service/contributions/ticket_labeling_service.rb
+++ b/app/services/service/contributions/ticket_labeling_service.rb
@@ -8,6 +8,8 @@ module Service
       end
 
       def label_donation
+        return if RibonConfig.disable_labeling
+
         payer_contribution = next_contribution_to_label_the_donation
         return unless payer_contribution
 

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -55,6 +55,10 @@ RailsAdmin.config do |config|
     field :minimum_contribution_chargeable_fee_cents do
       label{ "minimum_contribution_chargeable_fee_cents (minimum fee to charge from a contribution in usdc cents (100 = one dollar))" }
     end
+
+    field :disable_labeling do
+      label{ "disable labeling of new contributions and donations" }
+    end
   end
 
   config.model DonationBlockchainTransaction do

--- a/db/migrate/20231018165918_add_disable_labeling_to_ribon_configs.rb
+++ b/db/migrate/20231018165918_add_disable_labeling_to_ribon_configs.rb
@@ -1,0 +1,5 @@
+class AddDisableLabelingToRibonConfigs < ActiveRecord::Migration[7.0]
+  def change
+    add_column :ribon_configs, :disable_labeling, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,32 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_17_182818) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_18_165918) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
+
+  create_table "accounts", force: :cascade do |t|
+    t.boolean "allow_password_change"
+    t.datetime "confirmation_sent_at"
+    t.string "confirmation_token"
+    t.datetime "confirmed_at"
+    t.string "encrypted_password"
+    t.string "image"
+    t.string "name"
+    t.string "nickname"
+    t.string "provider"
+    t.datetime "remember_created_at"
+    t.datetime "reset_password_sent_at"
+    t.string "reset_password_token"
+    t.json "tokens"
+    t.string "uid"
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_accounts_on_user_id"
+  end
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -427,8 +448,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_17_182818) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.text "impact_description"
-    t.string "donor_recipient"
     t.string "measurement_unit"
+    t.string "donor_recipient"
     t.index ["non_profit_id"], name: "index_non_profit_impacts_on_non_profit_id"
   end
 
@@ -559,6 +580,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_17_182818) do
     t.integer "default_chain_id"
     t.decimal "contribution_fee_percentage"
     t.integer "minimum_contribution_chargeable_fee_cents"
+    t.boolean "disable_labeling", default: false
   end
 
   create_table "sources", force: :cascade do |t|
@@ -718,6 +740,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_17_182818) do
     t.index ["owner_type", "owner_id"], name: "index_wallets_on_owner"
   end
 
+  add_foreign_key "accounts", "users"
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "articles", "authors"

--- a/spec/factories/ribon_configs.rb
+++ b/spec/factories/ribon_configs.rb
@@ -5,6 +5,7 @@
 #  id                                        :bigint           not null, primary key
 #  contribution_fee_percentage               :decimal(, )
 #  default_ticket_value                      :decimal(, )
+#  disable_labeling                          :boolean          default(FALSE)
 #  minimum_contribution_chargeable_fee_cents :integer
 #  created_at                                :datetime         not null
 #  updated_at                                :datetime         not null

--- a/spec/models/ribon_config_spec.rb
+++ b/spec/models/ribon_config_spec.rb
@@ -5,6 +5,7 @@
 #  id                                        :bigint           not null, primary key
 #  contribution_fee_percentage               :decimal(, )
 #  default_ticket_value                      :decimal(, )
+#  disable_labeling                          :boolean          default(FALSE)
 #  minimum_contribution_chargeable_fee_cents :integer
 #  created_at                                :datetime         not null
 #  updated_at                                :datetime         not null

--- a/spec/services/service/contributions/fees_labeling_service_spec.rb
+++ b/spec/services/service/contributions/fees_labeling_service_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Service::Contributions::FeesLabelingService, type: :service do
     let!(:contribution) { create(:contribution, person_payment:) }
     let!(:contribution_balance1) do
       create(:contribution_balance,
-             contribution: create(:contribution, receiver: contribution.receiver,
+             contribution: create(:contribution, receiver: contribution.cause,
                                                  person_payment: create(:person_payment,
                                                                         :with_payment_in_blockchain,
                                                                         status: :paid)),
@@ -21,7 +21,7 @@ RSpec.describe Service::Contributions::FeesLabelingService, type: :service do
     end
     let!(:contribution_balance2) do
       create(:contribution_balance,
-             contribution: create(:contribution, receiver: contribution.receiver,
+             contribution: create(:contribution, receiver: contribution.cause,
                                                  person_payment: create(:person_payment,
                                                                         :with_payment_in_blockchain,
                                                                         status: :paid)),
@@ -29,7 +29,7 @@ RSpec.describe Service::Contributions::FeesLabelingService, type: :service do
     end
     let!(:contribution_balance3) do
       create(:contribution_balance,
-             contribution: create(:contribution, receiver: contribution.receiver,
+             contribution: create(:contribution, receiver: contribution.cause,
                                                  person_payment: create(:person_payment,
                                                                         :with_payment_in_blockchain,
                                                                         status: :paid)),
@@ -71,7 +71,7 @@ RSpec.describe Service::Contributions::FeesLabelingService, type: :service do
     # 4.545
     let!(:contribution_balance1) do
       create(:contribution_balance,
-             contribution: create(:contribution, receiver: contribution.receiver,
+             contribution: create(:contribution, receiver: contribution.cause,
                                                  person_payment: create(:person_payment,
                                                                         :with_payment_in_blockchain,
                                                                         status: :paid)),
@@ -80,7 +80,7 @@ RSpec.describe Service::Contributions::FeesLabelingService, type: :service do
     # 13.636
     let!(:contribution_balance2) do
       create(:contribution_balance,
-             contribution: create(:contribution, receiver: contribution.receiver,
+             contribution: create(:contribution, receiver: contribution.cause,
                                                  person_payment: create(:person_payment,
                                                                         :with_payment_in_blockchain,
                                                                         status: :paid)),
@@ -89,7 +89,7 @@ RSpec.describe Service::Contributions::FeesLabelingService, type: :service do
     # 27.272
     let!(:contribution_balance3) do
       create(:contribution_balance,
-             contribution: create(:contribution, receiver: contribution.receiver,
+             contribution: create(:contribution, receiver: contribution.cause,
                                                  person_payment: create(:person_payment,
                                                                         :with_payment_in_blockchain,
                                                                         status: :paid)),
@@ -98,7 +98,7 @@ RSpec.describe Service::Contributions::FeesLabelingService, type: :service do
     # 54.545
     let!(:contribution_balance4) do
       create(:contribution_balance,
-             contribution: create(:contribution, receiver: contribution.receiver,
+             contribution: create(:contribution, receiver: contribution.cause,
                                                  person_payment: create(:person_payment,
                                                                         :with_payment_in_blockchain,
                                                                         status: :paid)),


### PR DESCRIPTION
<!-- Delete any of those topics if they don't fit -->

# Description

- Update labeling to get cause instead of receiver
This is needed since non profits contributions can charge fees for the cause related to the non profit

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dangerous changes
- [ ] Chore (change that does not effect how the code works, eg: change color)
- [ ] Tests

