### PR TITLE
fix: relabel service to other causes

### DIFF
--- a/app/services/labeling/relabel_service.rb
+++ b/app/services/labeling/relabel_service.rb
@@ -23,12 +23,20 @@ module Labeling
 
     def setup_records
       ActiveRecord::Base.transaction do
-        @contributions = Contribution.where('created_at >= ?', from)
+        @contributions = Contribution.where(
+          "created_at >= ? and
+          (
+            (receiver_type = 'Cause' and receiver_id != 4) or
+            (receiver_type = 'NonProfit' and receiver_id not in (3,4,5,6,8,9))
+          )", 3.years.ago
+        )
         ContributionBalance.where(contribution: @contributions).delete_all
         @contributions.each(&:set_contribution_balance)
         ContributionFee.where(contribution: @contributions).delete_all
 
-        DonationContribution.where(donation: Donation.where('created_at >= ?', from)).delete_all
+        DonationContribution.where(donation: Donation.where(
+          'created_at >= ? AND donations.non_profit_id not in (3,4,5,6,8,9)', 3.years.ago
+        )).delete_all
       end
     end
 
@@ -61,16 +69,25 @@ module Labeling
 
     def donations
       @donations ||= Donation.select("donations.id, donations.created_at AS order_date, 'Donation' AS record_type")
-                             .where('donations.created_at >= ? AND donations.non_profit_id in (3,4,5,6,8,9)', from)
+                             .where('donations.created_at >= ? AND
+                              donations.non_profit_id not in (3,4,5,6,8,9)', from)
     end
 
     def person_blockchain_transactions
-      @person_blockchain_transactions ||= PersonBlockchainTransaction
-                                          .select("person_blockchain_transactions.id,
-       COALESCE(person_blockchain_transactions.succeeded_at,
-           person_blockchain_transactions.created_at) AS order_date,
-    'PersonBlockchainTransaction' AS record_type")
-                                          .where('person_blockchain_transactions.succeeded_at >= ?', from)
+      @person_blockchain_transactions ||=
+        PersonBlockchainTransaction.joins(:person_payment).select("person_blockchain_transactions.id,
+        COALESCE(person_blockchain_transactions.succeeded_at,
+            person_blockchain_transactions.created_at) AS order_date,
+      'PersonBlockchainTransaction' AS record_type")
+                                   .where(
+                                     "person_blockchain_transactions.succeeded_at >= ?
+                                                                       AND
+          (
+            (person_payments.receiver_type = 'Cause' and person_payments.receiver_id != 4) OR
+            (person_payments.receiver_type = 'NonProfit' and
+              person_payments.receiver_id not in (3,4,5,6,8,9))
+          )", 3.years.ago
+                                   )
     end
   end
 end


### PR DESCRIPTION
# Description

- For this time, relabel service should only run for non profits that are not in the health pool, also only rerun contributions that are not for the health pool.

