### PR TITLE
fix: enables donation if user has tickets

### DIFF
--- a/app/commands/tickets/collect_and_donate_by_external_ids.rb
+++ b/app/commands/tickets/collect_and_donate_by_external_ids.rb
@@ -48,7 +48,7 @@ module Tickets
     def collect_ticket
       command = CollectByExternalIds.call(integration:, user:, platform:, external_ids:)
 
-      if command.success?
+      if command.success? || user.tickets.any?
         donate_ticket
       else
         errors.add(:message, I18n.t('tickets.blocked_message'))

--- a/app/commands/tickets/collect_and_donate_by_integration.rb
+++ b/app/commands/tickets/collect_and_donate_by_integration.rb
@@ -47,7 +47,7 @@ module Tickets
     def collect_ticket
       command = CollectByIntegration.call(integration:, user:, platform:)
 
-      if command.success?
+      if command.success? || user.tickets.any?
         donate_ticket
       else
         errors.add(:message, I18n.t('donations.blocked_message'))


### PR DESCRIPTION
# Description

- enables donation if user has tickets when logging mid donation

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dangerous changes
- [ ] Chore (change that does not effect how the code works, eg: change color)
- [ ] Tests

## How to test

- logout from an account that has more than one tickets, try to donate by login in via magic link
