### PR TITLE
fix: fx donation event job for np with < 1 impact

### DIFF
--- a/app/jobs/events/donations/send_donation_event_job.rb
+++ b/app/jobs/events/donations/send_donation_event_job.rb
@@ -21,7 +21,7 @@ module Events
                            value: donation.value,
                            created_at: donation.created_at,
                            total_number_of_donations: donation.user.donations.count,
-                           donation_impact: impact_normalizer(donation.non_profit)
+                           donation_impact: normalized_impact(donation.non_profit)
                          }
                        })
       end
@@ -29,8 +29,12 @@ module Events
       def impact_normalizer(non_profit)
         Impact::Normalizer.new(
           non_profit,
-          non_profit.impact_by_ticket || 1
+          non_profit.impact_by_ticket
         ).normalize.join(' ')
+      end
+
+      def normalized_impact(non_profit)
+        non_profit.impact_by_ticket < 1 ? 0 : impact_normalizer(non_profit)
       end
     end
   end

--- a/app/jobs/events/donations/send_donation_event_job.rb
+++ b/app/jobs/events/donations/send_donation_event_job.rb
@@ -34,7 +34,7 @@ module Events
       end
 
       def normalized_impact(non_profit)
-        non_profit.impact_by_ticket < 1 ? 0 : impact_normalizer(non_profit)
+        non_profit.impact_by_ticket > 1 ? impact_normalizer(non_profit) : 'Non profit has small impact by ticket.'
       end
     end
   end

--- a/app/jobs/events/donations/send_donation_event_job.rb
+++ b/app/jobs/events/donations/send_donation_event_job.rb
@@ -29,7 +29,7 @@ module Events
       def impact_normalizer(non_profit)
         Impact::Normalizer.new(
           non_profit,
-          non_profit.impact_by_ticket
+          non_profit.impact_by_ticket || 1
         ).normalize.join(' ')
       end
     end

--- a/app/jobs/events/donations/send_donation_event_job.rb
+++ b/app/jobs/events/donations/send_donation_event_job.rb
@@ -34,7 +34,7 @@ module Events
       end
 
       def normalized_impact(non_profit)
-        non_profit.impact_by_ticket > 1 ? impact_normalizer(non_profit) : 'Non profit has small impact by ticket.'
+        non_profit.impact_by_ticket >= 1 ? impact_normalizer(non_profit) : 'Non profit has small impact by ticket.'
       end
     end
   end


### PR DESCRIPTION
Handles donation event for no profits with less than one impact_by_ticket so it won't raise "Impact can't be zero"