### PR TITLE
chore: remove send extra ticket email for magic link [PROD3-545]

### DIFF
--- a/app/commands/auth/accounts/send_authentication_email.rb
+++ b/app/commands/auth/accounts/send_authentication_email.rb
@@ -61,10 +61,7 @@ module Auth
       end
 
       def url(account)
-        url = Auth::EmailLinkService.new(authenticatable: account).find_or_create_auth_link
-        return "#{url}&extra_ticket=true" if first_access_to_integration?
-
-        url
+        Auth::EmailLinkService.new(authenticatable: account).find_or_create_auth_link
       end
 
       def build_event(account)
@@ -72,7 +69,6 @@ module Auth
                          name: 'authorize_email',
                          data: {
                            email: account.email,
-                           new_user: first_access_to_integration?,
                            url: url(account)
                          }
                        })

--- a/spec/commands/auth/accounts/send_authentication_email_spec.rb
+++ b/spec/commands/auth/accounts/send_authentication_email_spec.rb
@@ -21,14 +21,13 @@ describe Auth::Accounts::SendAuthenticationEmail do
     allow(event_service_double).to receive(:call)
   end
 
-  describe 'when user have not received an extra ticket and it is the first access' do
-    let(:url) { 'https://auth.ribon.io/link&extra_ticket=true' }
+  describe 'when the user receives an email' do
+    let(:url) { 'https://auth.ribon.io/link' }
     let(:event) do
       OpenStruct.new({
                        name: 'authorize_email',
                        data: {
                          email: authenticatable.email,
-                         new_user: true,
                          url:
                        }
                      })
@@ -71,35 +70,6 @@ describe Auth::Accounts::SendAuthenticationEmail do
       it 'returns a error message' do
         expect(command.errors[:message]).to eq(['Email does not match'])
       end
-    end
-  end
-
-  describe 'when user already received an extra ticket and it is not the first access' do
-    let(:url) { 'https://auth.ribon.io/link' }
-    let(:event) do
-      OpenStruct.new({
-                       name: 'authorize_email',
-                       data: {
-                         email: authenticatable.email,
-                         new_user: false,
-                         url:
-                       }
-                     })
-    end
-
-    before do
-      create(:donation, user: authenticatable.user, integration:)
-    end
-
-    it 'calls EventServices::SendEvent with correct arguments' do
-      command
-      expect(EventServices::SendEvent).to have_received(:new).with({ user: authenticatable.user,
-                                                                     event: })
-    end
-
-    it 'calls EventServices::SendEvent call' do
-      command
-      expect(event_service_double).to have_received(:call)
     end
   end
 end


### PR DESCRIPTION
# Description

- Remove validation send extra ticket email to first donation in magic link

## Type of change

Please delete options that are not relevant.
- [X] Chore
- [X] Test

## How to test
- Make a first donation and check that the email received is not an extra ticket.
