### PR TITLE
fix: allow command to reset all user donation stats at once

### DIFF
--- a/app/commands/users/reset_donation_streak.rb
+++ b/app/commands/users/reset_donation_streak.rb
@@ -4,15 +4,15 @@ module Users
   class ResetDonationStreak < ApplicationCommand
     prepend SimpleCommand
 
-    attr_reader :user_donation_stats
+    attr_reader :users_donation_stats
 
-    def initialize(user_donation_stats:)
-      @user_donation_stats = user_donation_stats
+    def initialize(users_donation_stats:)
+      @users_donation_stats = users_donation_stats
     end
 
     def call
       with_exception_handle do
-        return unless user_donation_stats
+        return if users_donation_stats&.length&.zero?
 
         reset_streak
       end
@@ -21,7 +21,7 @@ module Users
     private
 
     def reset_streak
-      @user_donation_stats.update(streak: 0)
+      users_donation_stats.update(streak: 0)
     end
   end
 end

--- a/app/jobs/users/reset_donation_streak_job.rb
+++ b/app/jobs/users/reset_donation_streak_job.rb
@@ -2,8 +2,8 @@ module Users
   class ResetDonationStreakJob < ApplicationJob
     queue_as :users
 
-    def perform(user_donation_stats:)
-      ResetDonationStreak.call(user_donation_stats:)
+    def perform(users_donation_stats:)
+      ResetDonationStreak.call(users_donation_stats:)
     end
   end
 end

--- a/app/workers/users/reset_donation_streak_worker.rb
+++ b/app/workers/users/reset_donation_streak_worker.rb
@@ -5,9 +5,7 @@ module Users
 
     def perform(*_args)
       users_donation_stats = UserDonationStats.where('streak > 0 AND last_donation_at < ?', Time.zone.yesterday)
-      users_donation_stats.each do |user_donation_stats|
-        ResetDonationStreakJob.perform_later(user_donation_stats:)
-      end
+      ResetDonationStreakJob.perform_later(users_donation_stats:)
     rescue StandardError => e
       Reporter.log(error: e, extra: { message: e.message })
     end

--- a/app/workers/users/reset_everyone_donation_streak_worker.rb
+++ b/app/workers/users/reset_everyone_donation_streak_worker.rb
@@ -4,9 +4,8 @@ module Users
     sidekiq_options queue: :users
 
     def perform(*_args)
-      UserDonationStats.all.each do |user_donation_stats|
-        ResetDonationStreakJob.perform_later(user_donation_stats:)
-      end
+      users_donation_stats = UserDonationStats.all
+      ResetDonationStreakJob.perform_later(users_donation_stats:)
     rescue StandardError => e
       Reporter.log(error: e, extra: { message: e.message })
     end

--- a/spec/commands/users/reset_donation_streak_spec.rb
+++ b/spec/commands/users/reset_donation_streak_spec.rb
@@ -6,7 +6,8 @@ describe Users::ResetDonationStreak do
   describe '.call' do
     let(:user) { create(:user) }
     let!(:user_donation_stats) { user.user_donation_stats }
-    let(:command) { described_class.call(user_donation_stats:) }
+    let!(:users_donation_stats) { UserDonationStats.all }
+    let(:command) { described_class.call(users_donation_stats:) }
 
     context 'when there is last donation at 2 days ago or more' do
       before do

--- a/spec/jobs/users/reset_donation_streak_job_spec.rb
+++ b/spec/jobs/users/reset_donation_streak_job_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe Users::ResetDonationStreakJob, type: :job do
+  describe '#perform' do
+    subject(:perform_job) { described_class.perform_now(users_donation_stats:) }
+
+    let!(:users_donation_stats) { UserDonationStats.all }
+
+    before do
+      create_list(:user_donation_stats, 10, streak: 5)
+      perform_job
+    end
+
+    it 'update the streak to zero' do
+      expect(users_donation_stats.pluck(:streak)).to eq([0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+    end
+  end
+end

--- a/spec/workers/users/reset_donation_streak_worker_spec.rb
+++ b/spec/workers/users/reset_donation_streak_worker_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+require 'sidekiq/testing'
+
+RSpec.describe Users::ResetDonationStreakWorker, type: :worker do
+  describe '#perform' do
+    subject(:worker) { described_class.new }
+
+    let(:users_donation_stats) do
+      UserDonationStats.where('streak > 0 AND last_donation_at < ?', Time.zone.yesterday)
+    end
+
+    before do
+      allow(Users::ResetDonationStreakJob).to receive(:perform_later)
+      create_list(:user_donation_stats, 10, streak: 5, last_donation_at: Time.zone.yesterday - 1.day)
+    end
+
+    it 'calls the ResetDonationsStreakJob' do
+      worker.perform
+
+      expect(Users::ResetDonationStreakJob).to have_received(:perform_later).with(users_donation_stats:)
+    end
+  end
+
+  describe '.perform_async' do
+    it 'expects to enqueue a job' do
+      expect do
+        described_class.perform_async
+      end.to change(described_class.jobs, :size).from(0).to(1)
+    end
+
+    it 'expects to add one job in the tickets queue' do
+      expect do
+        described_class.perform_async
+      end.to change(Sidekiq::Queues['users'], :size).by(1)
+    end
+  end
+end

--- a/spec/workers/users/reset_everyone_donation_streak_worker_spec.rb
+++ b/spec/workers/users/reset_everyone_donation_streak_worker_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+require 'sidekiq/testing'
+
+RSpec.describe Users::ResetEveryoneDonationStreakWorker, type: :worker do
+  describe '#perform' do
+    subject(:worker) { described_class.new }
+
+    let(:users_donation_stats) { UserDonationStats.all }
+
+    before do
+      allow(Users::ResetDonationStreakJob).to receive(:perform_later)
+      create_list(:user_donation_stats, 10, streak: 5)
+    end
+
+    it 'calls the ResetDonationsStreakJob' do
+      worker.perform
+
+      expect(Users::ResetDonationStreakJob).to have_received(:perform_later).with(users_donation_stats:)
+    end
+  end
+
+  describe '.perform_async' do
+    it 'expects to enqueue a job' do
+      expect do
+        described_class.perform_async
+      end.to change(described_class.jobs, :size).from(0).to(1)
+    end
+
+    it 'expects to add one job in the tickets queue' do
+      expect do
+        described_class.perform_async
+      end.to change(Sidekiq::Queues['users'], :size).by(1)
+    end
+  end
+end


### PR DESCRIPTION
<!-- Delete any of those topics if they don't fit -->

# Description

- allow command to reset all user donation stats at once

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dangerous changes
- [ ] Chore (change that does not effect how the code works, eg: change color)
- [ ] Tests

## How to test

Put here all the things need to test this PR and verify your changes, also list any relevant details for tests (eg: have a wallet)

- Test A
