### PR TITLE
feat: adds send inactivated club event

### DIFF
--- a/app/observers/subscription_observer.rb
+++ b/app/observers/subscription_observer.rb
@@ -2,6 +2,7 @@ class SubscriptionObserver < ActiveRecord::Observer
   def after_update(subscription)
     Events::Club::SendActivatedClubEventJob.perform_later(subscription:) if club_inactive_to_active?(subscription)
     Events::Club::SendCanceledClubEventJob.perform_later(subscription:) if club_active_to_canceled?(subscription)
+    Events::Club::SendInactivatedClubEventJob.perform_later(subscription:) if club_revoked?(subscription)
   rescue StandardError
     nil
   end
@@ -12,5 +13,10 @@ class SubscriptionObserver < ActiveRecord::Observer
 
   def club_active_to_canceled?(subscription)
     subscription.category == 'club' && subscription.previous_changes[:status] == %w[active canceled]
+  end
+
+  def club_revoked?(subscription)
+    subscription.category == 'club' && subscription.payment_method == 'pix' &&
+      subscription.previous_changes[:status] == %w[active inactive]
   end
 end

--- a/spec/jobs/events/club/send_inactivated_club_event_job_spec.rb
+++ b/spec/jobs/events/club/send_inactivated_club_event_job_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+require 'sidekiq/testing'
+
+RSpec.describe Events::Club::SendInactivatedClubEventJob, type: :job do
+  describe '#perform' do
+    subject(:perform_job) { described_class }
+
+    let(:user) { create(:user) }
+    let(:customer) { create(:customer, user:) }
+    let(:subscription) { create(:subscription) }
+    let(:offer) { create(:offer) }
+    let!(:person_payment) do
+      create(:person_payment, payer: customer, status: :failed, subscription:, offer:)
+    end
+    let(:event_service_double) { instance_double(EventServices::SendEvent) }
+
+    let(:event) do
+      OpenStruct.new({
+                       name: 'club',
+                       data: {
+                         type: 'pix_club_inactivated',
+                         subscription_id: subscription.id,
+                         integration_id: person_payment.integration_id,
+                         currency: person_payment.currency,
+                         platform: person_payment.platform,
+                         amount: person_payment.formatted_amount,
+                         status: subscription.status,
+                         offer_id: person_payment.offer_id,
+                         last_club_day: (person_payment.created_at + 1.month).strftime('%d/%m/%Y'),
+                         payment_day: person_payment.created_at.day
+                       }
+                     })
+    end
+
+    before do
+      create(:ribon_config)
+      allow(EventServices::SendEvent).to receive(:new).and_return(event_service_double)
+      allow(event_service_double).to receive(:call)
+    end
+
+    it 'calls the send event function with correct arguments' do
+      perform_job.perform_now(subscription:)
+
+      expect(EventServices::SendEvent).to have_received(:new).with(
+        user: person_payment.payer.user, event:
+      )
+    end
+  end
+end


### PR DESCRIPTION
<!-- Delete any of those topics if they don't fit -->

# Description

- Sends the club event with the pix_club_inactivated type so that customer.io can send the email 

## Does this pull request close any open issues?

- No

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Dangerous changes
- [ ] Chore (change that does not affect how the code works, eg: change color)
- [ ] Tests


