### PR TITLE
fix: legacy non profit logo transparency

### DIFF
--- a/app/blueprints/legacy_non_profit_blueprint.rb
+++ b/app/blueprints/legacy_non_profit_blueprint.rb
@@ -6,6 +6,6 @@ class LegacyNonProfitBlueprint < Blueprinter::Base
 
   field(:logo_url) do |object|
     ImagesHelper.image_url_for(object.logo, variant: { resize_to_fit: [150, 150],
-                                                       saver: { quality: 95 }, format: :jpg })
+                                                       saver: { quality: 95 }, format: :png })
   end
 end


### PR DESCRIPTION
<!-- Delete any of those topics if they don't fit -->

# Description

The legacy non profit logos where coming with a black square surrounding them. Because we were using jpg instead of png

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dangerous changes
- [ ] Chore (change that does not effect how the code works, eg: change color)
- [ ] Tests

# Photos
![image](https://github.com/RibonDAO/core-api/assets/57116106/7f82581f-d8cc-40af-8aee-5c42b2ddd864)
