### PR TITLE
feat: return account id when sending an OTP email

### DIFF
--- a/app/commands/auth/accounts/send_otp_email.rb
+++ b/app/commands/auth/accounts/send_otp_email.rb
@@ -22,7 +22,7 @@ module Auth
           access_token, refresh_token = Jwt::Auth::Issuer.call(@account)
           Users::CreateProfile.call(data: {}, user: @account.user)
           send_event
-          { access_token:, refresh_token:, user: @account.user, account_id: @account.id }
+          { access_token:, refresh_token:, account: @account, user: @account.user }
         rescue StandardError => e
           errors.add(:message, e.message)
         end

--- a/app/commands/auth/accounts/send_otp_email.rb
+++ b/app/commands/auth/accounts/send_otp_email.rb
@@ -22,7 +22,7 @@ module Auth
           access_token, refresh_token = Jwt::Auth::Issuer.call(@account)
           Users::CreateProfile.call(data: {}, user: @account.user)
           send_event
-          { access_token:, refresh_token:, user: @account.user }
+          { access_token:, refresh_token:, user: @account.user, account_id: @account.id }
         rescue StandardError => e
           errors.add(:message, e.message)
         end

--- a/app/controllers/users/v1/authentication_controller.rb
+++ b/app/controllers/users/v1/authentication_controller.rb
@@ -1,3 +1,4 @@
+# rubocop:disable Metrics/ClassLength
 module Users
   module V1
     class AuthenticationController < Users::AuthorizationController
@@ -54,10 +55,11 @@ module Users
                                                     id: params[:account_id])
 
         if command.success?
-          render json: { message: I18n.t('users.email_sent'), user: command.result[:user], account_id: command.result[:account_id] },
+          render json: { message: I18n.t('users.email_sent'),
+                         account_id: command.result[:account].id,
+                         user: command.result[:user] },
                  status: :ok
         else
-
           render_errors(command.errors, :unprocessable_entity)
         end
       end
@@ -130,3 +132,4 @@ module Users
     end
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/app/controllers/users/v1/authentication_controller.rb
+++ b/app/controllers/users/v1/authentication_controller.rb
@@ -54,7 +54,7 @@ module Users
                                                     id: params[:account_id])
 
         if command.success?
-          render json: { message: I18n.t('users.email_sent'), user: command.result[:user] }, status: :ok
+          render json: { message: I18n.t('users.email_sent'), user: command.result[:user], account_id: command.result[:account_id] }, status: :ok
         else
 
           render_errors(command.errors, :unprocessable_entity)

--- a/app/controllers/users/v1/authentication_controller.rb
+++ b/app/controllers/users/v1/authentication_controller.rb
@@ -54,7 +54,8 @@ module Users
                                                     id: params[:account_id])
 
         if command.success?
-          render json: { message: I18n.t('users.email_sent'), user: command.result[:user], account_id: command.result[:account_id] }, status: :ok
+          render json: { message: I18n.t('users.email_sent'), user: command.result[:user], account_id: command.result[:account_id] },
+                 status: :ok
         else
 
           render_errors(command.errors, :unprocessable_entity)

--- a/spec/requests/users/v1/authentication_spec.rb
+++ b/spec/requests/users/v1/authentication_spec.rb
@@ -93,13 +93,15 @@ RSpec.describe 'Users::V1::Authentication', type: :request do
     subject(:request) { post '/users/v1/auth/send_otp_email', params: }
 
     let(:user) { create(:user) }
+    let(:account) { create(:account, user: user) }
     let(:params) { { email: user.email } }
     let(:command) { command_double(klass: Auth::Accounts::SendOtpEmail, success: true, result:) }
 
     let(:result) do
       { access_token: 'access_token',
         refresh_token: OpenStruct.new({ token: 'refresh_token' }),
-        user: }
+        user:,
+        account: }
     end
 
     before do

--- a/spec/requests/users/v1/authentication_spec.rb
+++ b/spec/requests/users/v1/authentication_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe 'Users::V1::Authentication', type: :request do
     subject(:request) { post '/users/v1/auth/send_otp_email', params: }
 
     let(:user) { create(:user) }
-    let(:account) { create(:account, user: user) }
+    let(:account) { create(:account, user:) }
     let(:params) { { email: user.email } }
     let(:command) { command_double(klass: Auth::Accounts::SendOtpEmail, success: true, result:) }
 


### PR DESCRIPTION
<!-- Delete any of those topics if they don't fit -->

# Description
 - Send back the account id when a OTP e-mail is sent.


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Dangerous changes
- [ ] Chore (change that does not effect how the code works, eg: change color)
- [ ] Tests