### PR TITLE
fix: fixes direct_transfer subscription constraint

### DIFF
--- a/app/commands/givings/subscriptions/create_direct_transfer_subscription.rb
+++ b/app/commands/givings/subscriptions/create_direct_transfer_subscription.rb
@@ -77,7 +77,7 @@ module Givings
       end
 
       def subscription_already_exists(payer)
-        Subscription.exists?(payer:, status: :active)
+        Subscription.exists?(payer:, status: :active, payment_method: :direct_transfer)
       end
     end
   end

--- a/spec/requests/managers/v1/subscriptions_spec.rb
+++ b/spec/requests/managers/v1/subscriptions_spec.rb
@@ -29,10 +29,10 @@ RSpec.describe 'Managers::V1::SubscriptionsController', type: :request do
     end
 
     context 'when one user already has an active subscription' do
-      it 'does not create a new one for them' do
+      it 'creates a new one for them' do
         create(:plan, offer:)
         create(:subscription, payer: create(:customer, user: create(:user, email: 'clara@ribon.io')))
-        expect { request }.to change(Subscription, :count).by(2)
+        expect { request }.to change(Subscription, :count).by(3)
       end
     end
   end


### PR DESCRIPTION
# Description

- Fixes existing subscription verification so we can create direct_transfer subscriptions even for existing subscribers

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dangerous changes
- [ ] Chore (change that does not effect how the code works, eg: change color)
- [ ] Tests


